### PR TITLE
fix(core): prioritize git branch over sticky file in feature detection

### DIFF
--- a/.claude/skills/iikit-00-constitution/scripts/bash/common.sh
+++ b/.claude/skills/iikit-00-constitution/scripts/bash/common.sh
@@ -154,28 +154,44 @@ get_repo_root() {
 }
 
 # Get current branch, with fallback for non-git repositories
-# Detection cascade: active-feature file > SPECIFY_FEATURE env > git branch > single feature > fallback
+# Detection cascade: SPECIFY_FEATURE env > git feature branch (NNN-*) > active-feature file > git branch (non-feature) > active-feature (non-git) > scan specs dir > fallback
 get_current_branch() {
-    # 1. Check sticky active-feature file (survives restarts)
+    # 1. Check SPECIFY_FEATURE environment variable (explicit CI override)
+    if [[ -n "${SPECIFY_FEATURE:-}" ]]; then
+        echo "$SPECIFY_FEATURE"
+        return
+    fi
+
+    # 2. Check git branch — if it matches a feature pattern (NNN-*), use it
+    #    This ensures switching branches always picks up the correct feature,
+    #    even when a stale active-feature file points elsewhere.
+    local git_branch
+    git_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) && [[ -n "$git_branch" ]] && {
+        if [[ "$git_branch" =~ ^[0-9]{3}- ]]; then
+            echo "$git_branch"
+            return
+        fi
+
+        # 3. On a non-feature branch (e.g. main): fall back to sticky active-feature file
+        local active
+        active=$(read_active_feature 2>/dev/null) && [[ -n "$active" ]] && {
+            echo "$active"
+            return
+        }
+
+        # 4. Non-feature git branch, no sticky file — return branch as-is
+        echo "$git_branch"
+        return
+    }
+
+    # 5. Non-git: check sticky active-feature file
     local active
     active=$(read_active_feature 2>/dev/null) && [[ -n "$active" ]] && {
         echo "$active"
         return
     }
 
-    # 2. Check SPECIFY_FEATURE environment variable (CI/scripts)
-    if [[ -n "${SPECIFY_FEATURE:-}" ]]; then
-        echo "$SPECIFY_FEATURE"
-        return
-    fi
-
-    # 3. Check git branch if available
-    if git rev-parse --abbrev-ref HEAD >/dev/null 2>&1; then
-        git rev-parse --abbrev-ref HEAD
-        return
-    fi
-
-    # 4. For non-git repos, try to find the latest feature directory
+    # 6. For non-git repos, try to find the latest feature directory
     local repo_root=$(get_repo_root)
     local specs_dir="$repo_root/specs"
 
@@ -203,7 +219,8 @@ get_current_branch() {
         fi
     fi
 
-    echo "main"  # Final fallback
+    # 7. Final fallback
+    echo "main"
 }
 
 # Check if we have git available

--- a/.claude/skills/iikit-01-specify/scripts/bash/common.sh
+++ b/.claude/skills/iikit-01-specify/scripts/bash/common.sh
@@ -154,28 +154,44 @@ get_repo_root() {
 }
 
 # Get current branch, with fallback for non-git repositories
-# Detection cascade: active-feature file > SPECIFY_FEATURE env > git branch > single feature > fallback
+# Detection cascade: SPECIFY_FEATURE env > git feature branch (NNN-*) > active-feature file > git branch (non-feature) > active-feature (non-git) > scan specs dir > fallback
 get_current_branch() {
-    # 1. Check sticky active-feature file (survives restarts)
+    # 1. Check SPECIFY_FEATURE environment variable (explicit CI override)
+    if [[ -n "${SPECIFY_FEATURE:-}" ]]; then
+        echo "$SPECIFY_FEATURE"
+        return
+    fi
+
+    # 2. Check git branch — if it matches a feature pattern (NNN-*), use it
+    #    This ensures switching branches always picks up the correct feature,
+    #    even when a stale active-feature file points elsewhere.
+    local git_branch
+    git_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) && [[ -n "$git_branch" ]] && {
+        if [[ "$git_branch" =~ ^[0-9]{3}- ]]; then
+            echo "$git_branch"
+            return
+        fi
+
+        # 3. On a non-feature branch (e.g. main): fall back to sticky active-feature file
+        local active
+        active=$(read_active_feature 2>/dev/null) && [[ -n "$active" ]] && {
+            echo "$active"
+            return
+        }
+
+        # 4. Non-feature git branch, no sticky file — return branch as-is
+        echo "$git_branch"
+        return
+    }
+
+    # 5. Non-git: check sticky active-feature file
     local active
     active=$(read_active_feature 2>/dev/null) && [[ -n "$active" ]] && {
         echo "$active"
         return
     }
 
-    # 2. Check SPECIFY_FEATURE environment variable (CI/scripts)
-    if [[ -n "${SPECIFY_FEATURE:-}" ]]; then
-        echo "$SPECIFY_FEATURE"
-        return
-    fi
-
-    # 3. Check git branch if available
-    if git rev-parse --abbrev-ref HEAD >/dev/null 2>&1; then
-        git rev-parse --abbrev-ref HEAD
-        return
-    fi
-
-    # 4. For non-git repos, try to find the latest feature directory
+    # 6. For non-git repos, try to find the latest feature directory
     local repo_root=$(get_repo_root)
     local specs_dir="$repo_root/specs"
 
@@ -203,7 +219,8 @@ get_current_branch() {
         fi
     fi
 
-    echo "main"  # Final fallback
+    # 7. Final fallback
+    echo "main"
 }
 
 # Check if we have git available

--- a/.claude/skills/iikit-02-plan/scripts/bash/common.sh
+++ b/.claude/skills/iikit-02-plan/scripts/bash/common.sh
@@ -154,28 +154,44 @@ get_repo_root() {
 }
 
 # Get current branch, with fallback for non-git repositories
-# Detection cascade: active-feature file > SPECIFY_FEATURE env > git branch > single feature > fallback
+# Detection cascade: SPECIFY_FEATURE env > git feature branch (NNN-*) > active-feature file > git branch (non-feature) > active-feature (non-git) > scan specs dir > fallback
 get_current_branch() {
-    # 1. Check sticky active-feature file (survives restarts)
+    # 1. Check SPECIFY_FEATURE environment variable (explicit CI override)
+    if [[ -n "${SPECIFY_FEATURE:-}" ]]; then
+        echo "$SPECIFY_FEATURE"
+        return
+    fi
+
+    # 2. Check git branch — if it matches a feature pattern (NNN-*), use it
+    #    This ensures switching branches always picks up the correct feature,
+    #    even when a stale active-feature file points elsewhere.
+    local git_branch
+    git_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) && [[ -n "$git_branch" ]] && {
+        if [[ "$git_branch" =~ ^[0-9]{3}- ]]; then
+            echo "$git_branch"
+            return
+        fi
+
+        # 3. On a non-feature branch (e.g. main): fall back to sticky active-feature file
+        local active
+        active=$(read_active_feature 2>/dev/null) && [[ -n "$active" ]] && {
+            echo "$active"
+            return
+        }
+
+        # 4. Non-feature git branch, no sticky file — return branch as-is
+        echo "$git_branch"
+        return
+    }
+
+    # 5. Non-git: check sticky active-feature file
     local active
     active=$(read_active_feature 2>/dev/null) && [[ -n "$active" ]] && {
         echo "$active"
         return
     }
 
-    # 2. Check SPECIFY_FEATURE environment variable (CI/scripts)
-    if [[ -n "${SPECIFY_FEATURE:-}" ]]; then
-        echo "$SPECIFY_FEATURE"
-        return
-    fi
-
-    # 3. Check git branch if available
-    if git rev-parse --abbrev-ref HEAD >/dev/null 2>&1; then
-        git rev-parse --abbrev-ref HEAD
-        return
-    fi
-
-    # 4. For non-git repos, try to find the latest feature directory
+    # 6. For non-git repos, try to find the latest feature directory
     local repo_root=$(get_repo_root)
     local specs_dir="$repo_root/specs"
 
@@ -203,7 +219,8 @@ get_current_branch() {
         fi
     fi
 
-    echo "main"  # Final fallback
+    # 7. Final fallback
+    echo "main"
 }
 
 # Check if we have git available

--- a/.claude/skills/iikit-03-checklist/scripts/bash/common.sh
+++ b/.claude/skills/iikit-03-checklist/scripts/bash/common.sh
@@ -154,28 +154,44 @@ get_repo_root() {
 }
 
 # Get current branch, with fallback for non-git repositories
-# Detection cascade: active-feature file > SPECIFY_FEATURE env > git branch > single feature > fallback
+# Detection cascade: SPECIFY_FEATURE env > git feature branch (NNN-*) > active-feature file > git branch (non-feature) > active-feature (non-git) > scan specs dir > fallback
 get_current_branch() {
-    # 1. Check sticky active-feature file (survives restarts)
+    # 1. Check SPECIFY_FEATURE environment variable (explicit CI override)
+    if [[ -n "${SPECIFY_FEATURE:-}" ]]; then
+        echo "$SPECIFY_FEATURE"
+        return
+    fi
+
+    # 2. Check git branch — if it matches a feature pattern (NNN-*), use it
+    #    This ensures switching branches always picks up the correct feature,
+    #    even when a stale active-feature file points elsewhere.
+    local git_branch
+    git_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) && [[ -n "$git_branch" ]] && {
+        if [[ "$git_branch" =~ ^[0-9]{3}- ]]; then
+            echo "$git_branch"
+            return
+        fi
+
+        # 3. On a non-feature branch (e.g. main): fall back to sticky active-feature file
+        local active
+        active=$(read_active_feature 2>/dev/null) && [[ -n "$active" ]] && {
+            echo "$active"
+            return
+        }
+
+        # 4. Non-feature git branch, no sticky file — return branch as-is
+        echo "$git_branch"
+        return
+    }
+
+    # 5. Non-git: check sticky active-feature file
     local active
     active=$(read_active_feature 2>/dev/null) && [[ -n "$active" ]] && {
         echo "$active"
         return
     }
 
-    # 2. Check SPECIFY_FEATURE environment variable (CI/scripts)
-    if [[ -n "${SPECIFY_FEATURE:-}" ]]; then
-        echo "$SPECIFY_FEATURE"
-        return
-    fi
-
-    # 3. Check git branch if available
-    if git rev-parse --abbrev-ref HEAD >/dev/null 2>&1; then
-        git rev-parse --abbrev-ref HEAD
-        return
-    fi
-
-    # 4. For non-git repos, try to find the latest feature directory
+    # 6. For non-git repos, try to find the latest feature directory
     local repo_root=$(get_repo_root)
     local specs_dir="$repo_root/specs"
 
@@ -203,7 +219,8 @@ get_current_branch() {
         fi
     fi
 
-    echo "main"  # Final fallback
+    # 7. Final fallback
+    echo "main"
 }
 
 # Check if we have git available

--- a/.claude/skills/iikit-04-testify/scripts/bash/common.sh
+++ b/.claude/skills/iikit-04-testify/scripts/bash/common.sh
@@ -154,28 +154,44 @@ get_repo_root() {
 }
 
 # Get current branch, with fallback for non-git repositories
-# Detection cascade: active-feature file > SPECIFY_FEATURE env > git branch > single feature > fallback
+# Detection cascade: SPECIFY_FEATURE env > git feature branch (NNN-*) > active-feature file > git branch (non-feature) > active-feature (non-git) > scan specs dir > fallback
 get_current_branch() {
-    # 1. Check sticky active-feature file (survives restarts)
+    # 1. Check SPECIFY_FEATURE environment variable (explicit CI override)
+    if [[ -n "${SPECIFY_FEATURE:-}" ]]; then
+        echo "$SPECIFY_FEATURE"
+        return
+    fi
+
+    # 2. Check git branch — if it matches a feature pattern (NNN-*), use it
+    #    This ensures switching branches always picks up the correct feature,
+    #    even when a stale active-feature file points elsewhere.
+    local git_branch
+    git_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) && [[ -n "$git_branch" ]] && {
+        if [[ "$git_branch" =~ ^[0-9]{3}- ]]; then
+            echo "$git_branch"
+            return
+        fi
+
+        # 3. On a non-feature branch (e.g. main): fall back to sticky active-feature file
+        local active
+        active=$(read_active_feature 2>/dev/null) && [[ -n "$active" ]] && {
+            echo "$active"
+            return
+        }
+
+        # 4. Non-feature git branch, no sticky file — return branch as-is
+        echo "$git_branch"
+        return
+    }
+
+    # 5. Non-git: check sticky active-feature file
     local active
     active=$(read_active_feature 2>/dev/null) && [[ -n "$active" ]] && {
         echo "$active"
         return
     }
 
-    # 2. Check SPECIFY_FEATURE environment variable (CI/scripts)
-    if [[ -n "${SPECIFY_FEATURE:-}" ]]; then
-        echo "$SPECIFY_FEATURE"
-        return
-    fi
-
-    # 3. Check git branch if available
-    if git rev-parse --abbrev-ref HEAD >/dev/null 2>&1; then
-        git rev-parse --abbrev-ref HEAD
-        return
-    fi
-
-    # 4. For non-git repos, try to find the latest feature directory
+    # 6. For non-git repos, try to find the latest feature directory
     local repo_root=$(get_repo_root)
     local specs_dir="$repo_root/specs"
 
@@ -203,7 +219,8 @@ get_current_branch() {
         fi
     fi
 
-    echo "main"  # Final fallback
+    # 7. Final fallback
+    echo "main"
 }
 
 # Check if we have git available

--- a/.claude/skills/iikit-05-tasks/scripts/bash/common.sh
+++ b/.claude/skills/iikit-05-tasks/scripts/bash/common.sh
@@ -154,28 +154,44 @@ get_repo_root() {
 }
 
 # Get current branch, with fallback for non-git repositories
-# Detection cascade: active-feature file > SPECIFY_FEATURE env > git branch > single feature > fallback
+# Detection cascade: SPECIFY_FEATURE env > git feature branch (NNN-*) > active-feature file > git branch (non-feature) > active-feature (non-git) > scan specs dir > fallback
 get_current_branch() {
-    # 1. Check sticky active-feature file (survives restarts)
+    # 1. Check SPECIFY_FEATURE environment variable (explicit CI override)
+    if [[ -n "${SPECIFY_FEATURE:-}" ]]; then
+        echo "$SPECIFY_FEATURE"
+        return
+    fi
+
+    # 2. Check git branch — if it matches a feature pattern (NNN-*), use it
+    #    This ensures switching branches always picks up the correct feature,
+    #    even when a stale active-feature file points elsewhere.
+    local git_branch
+    git_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) && [[ -n "$git_branch" ]] && {
+        if [[ "$git_branch" =~ ^[0-9]{3}- ]]; then
+            echo "$git_branch"
+            return
+        fi
+
+        # 3. On a non-feature branch (e.g. main): fall back to sticky active-feature file
+        local active
+        active=$(read_active_feature 2>/dev/null) && [[ -n "$active" ]] && {
+            echo "$active"
+            return
+        }
+
+        # 4. Non-feature git branch, no sticky file — return branch as-is
+        echo "$git_branch"
+        return
+    }
+
+    # 5. Non-git: check sticky active-feature file
     local active
     active=$(read_active_feature 2>/dev/null) && [[ -n "$active" ]] && {
         echo "$active"
         return
     }
 
-    # 2. Check SPECIFY_FEATURE environment variable (CI/scripts)
-    if [[ -n "${SPECIFY_FEATURE:-}" ]]; then
-        echo "$SPECIFY_FEATURE"
-        return
-    fi
-
-    # 3. Check git branch if available
-    if git rev-parse --abbrev-ref HEAD >/dev/null 2>&1; then
-        git rev-parse --abbrev-ref HEAD
-        return
-    fi
-
-    # 4. For non-git repos, try to find the latest feature directory
+    # 6. For non-git repos, try to find the latest feature directory
     local repo_root=$(get_repo_root)
     local specs_dir="$repo_root/specs"
 
@@ -203,7 +219,8 @@ get_current_branch() {
         fi
     fi
 
-    echo "main"  # Final fallback
+    # 7. Final fallback
+    echo "main"
 }
 
 # Check if we have git available

--- a/.claude/skills/iikit-06-analyze/scripts/bash/common.sh
+++ b/.claude/skills/iikit-06-analyze/scripts/bash/common.sh
@@ -154,28 +154,44 @@ get_repo_root() {
 }
 
 # Get current branch, with fallback for non-git repositories
-# Detection cascade: active-feature file > SPECIFY_FEATURE env > git branch > single feature > fallback
+# Detection cascade: SPECIFY_FEATURE env > git feature branch (NNN-*) > active-feature file > git branch (non-feature) > active-feature (non-git) > scan specs dir > fallback
 get_current_branch() {
-    # 1. Check sticky active-feature file (survives restarts)
+    # 1. Check SPECIFY_FEATURE environment variable (explicit CI override)
+    if [[ -n "${SPECIFY_FEATURE:-}" ]]; then
+        echo "$SPECIFY_FEATURE"
+        return
+    fi
+
+    # 2. Check git branch — if it matches a feature pattern (NNN-*), use it
+    #    This ensures switching branches always picks up the correct feature,
+    #    even when a stale active-feature file points elsewhere.
+    local git_branch
+    git_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) && [[ -n "$git_branch" ]] && {
+        if [[ "$git_branch" =~ ^[0-9]{3}- ]]; then
+            echo "$git_branch"
+            return
+        fi
+
+        # 3. On a non-feature branch (e.g. main): fall back to sticky active-feature file
+        local active
+        active=$(read_active_feature 2>/dev/null) && [[ -n "$active" ]] && {
+            echo "$active"
+            return
+        }
+
+        # 4. Non-feature git branch, no sticky file — return branch as-is
+        echo "$git_branch"
+        return
+    }
+
+    # 5. Non-git: check sticky active-feature file
     local active
     active=$(read_active_feature 2>/dev/null) && [[ -n "$active" ]] && {
         echo "$active"
         return
     }
 
-    # 2. Check SPECIFY_FEATURE environment variable (CI/scripts)
-    if [[ -n "${SPECIFY_FEATURE:-}" ]]; then
-        echo "$SPECIFY_FEATURE"
-        return
-    fi
-
-    # 3. Check git branch if available
-    if git rev-parse --abbrev-ref HEAD >/dev/null 2>&1; then
-        git rev-parse --abbrev-ref HEAD
-        return
-    fi
-
-    # 4. For non-git repos, try to find the latest feature directory
+    # 6. For non-git repos, try to find the latest feature directory
     local repo_root=$(get_repo_root)
     local specs_dir="$repo_root/specs"
 
@@ -203,7 +219,8 @@ get_current_branch() {
         fi
     fi
 
-    echo "main"  # Final fallback
+    # 7. Final fallback
+    echo "main"
 }
 
 # Check if we have git available

--- a/.claude/skills/iikit-07-implement/scripts/bash/common.sh
+++ b/.claude/skills/iikit-07-implement/scripts/bash/common.sh
@@ -154,28 +154,44 @@ get_repo_root() {
 }
 
 # Get current branch, with fallback for non-git repositories
-# Detection cascade: active-feature file > SPECIFY_FEATURE env > git branch > single feature > fallback
+# Detection cascade: SPECIFY_FEATURE env > git feature branch (NNN-*) > active-feature file > git branch (non-feature) > active-feature (non-git) > scan specs dir > fallback
 get_current_branch() {
-    # 1. Check sticky active-feature file (survives restarts)
+    # 1. Check SPECIFY_FEATURE environment variable (explicit CI override)
+    if [[ -n "${SPECIFY_FEATURE:-}" ]]; then
+        echo "$SPECIFY_FEATURE"
+        return
+    fi
+
+    # 2. Check git branch — if it matches a feature pattern (NNN-*), use it
+    #    This ensures switching branches always picks up the correct feature,
+    #    even when a stale active-feature file points elsewhere.
+    local git_branch
+    git_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) && [[ -n "$git_branch" ]] && {
+        if [[ "$git_branch" =~ ^[0-9]{3}- ]]; then
+            echo "$git_branch"
+            return
+        fi
+
+        # 3. On a non-feature branch (e.g. main): fall back to sticky active-feature file
+        local active
+        active=$(read_active_feature 2>/dev/null) && [[ -n "$active" ]] && {
+            echo "$active"
+            return
+        }
+
+        # 4. Non-feature git branch, no sticky file — return branch as-is
+        echo "$git_branch"
+        return
+    }
+
+    # 5. Non-git: check sticky active-feature file
     local active
     active=$(read_active_feature 2>/dev/null) && [[ -n "$active" ]] && {
         echo "$active"
         return
     }
 
-    # 2. Check SPECIFY_FEATURE environment variable (CI/scripts)
-    if [[ -n "${SPECIFY_FEATURE:-}" ]]; then
-        echo "$SPECIFY_FEATURE"
-        return
-    fi
-
-    # 3. Check git branch if available
-    if git rev-parse --abbrev-ref HEAD >/dev/null 2>&1; then
-        git rev-parse --abbrev-ref HEAD
-        return
-    fi
-
-    # 4. For non-git repos, try to find the latest feature directory
+    # 6. For non-git repos, try to find the latest feature directory
     local repo_root=$(get_repo_root)
     local specs_dir="$repo_root/specs"
 
@@ -203,7 +219,8 @@ get_current_branch() {
         fi
     fi
 
-    echo "main"  # Final fallback
+    # 7. Final fallback
+    echo "main"
 }
 
 # Check if we have git available

--- a/.claude/skills/iikit-08-taskstoissues/scripts/bash/common.sh
+++ b/.claude/skills/iikit-08-taskstoissues/scripts/bash/common.sh
@@ -154,28 +154,44 @@ get_repo_root() {
 }
 
 # Get current branch, with fallback for non-git repositories
-# Detection cascade: active-feature file > SPECIFY_FEATURE env > git branch > single feature > fallback
+# Detection cascade: SPECIFY_FEATURE env > git feature branch (NNN-*) > active-feature file > git branch (non-feature) > active-feature (non-git) > scan specs dir > fallback
 get_current_branch() {
-    # 1. Check sticky active-feature file (survives restarts)
+    # 1. Check SPECIFY_FEATURE environment variable (explicit CI override)
+    if [[ -n "${SPECIFY_FEATURE:-}" ]]; then
+        echo "$SPECIFY_FEATURE"
+        return
+    fi
+
+    # 2. Check git branch — if it matches a feature pattern (NNN-*), use it
+    #    This ensures switching branches always picks up the correct feature,
+    #    even when a stale active-feature file points elsewhere.
+    local git_branch
+    git_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) && [[ -n "$git_branch" ]] && {
+        if [[ "$git_branch" =~ ^[0-9]{3}- ]]; then
+            echo "$git_branch"
+            return
+        fi
+
+        # 3. On a non-feature branch (e.g. main): fall back to sticky active-feature file
+        local active
+        active=$(read_active_feature 2>/dev/null) && [[ -n "$active" ]] && {
+            echo "$active"
+            return
+        }
+
+        # 4. Non-feature git branch, no sticky file — return branch as-is
+        echo "$git_branch"
+        return
+    }
+
+    # 5. Non-git: check sticky active-feature file
     local active
     active=$(read_active_feature 2>/dev/null) && [[ -n "$active" ]] && {
         echo "$active"
         return
     }
 
-    # 2. Check SPECIFY_FEATURE environment variable (CI/scripts)
-    if [[ -n "${SPECIFY_FEATURE:-}" ]]; then
-        echo "$SPECIFY_FEATURE"
-        return
-    fi
-
-    # 3. Check git branch if available
-    if git rev-parse --abbrev-ref HEAD >/dev/null 2>&1; then
-        git rev-parse --abbrev-ref HEAD
-        return
-    fi
-
-    # 4. For non-git repos, try to find the latest feature directory
+    # 6. For non-git repos, try to find the latest feature directory
     local repo_root=$(get_repo_root)
     local specs_dir="$repo_root/specs"
 
@@ -203,7 +219,8 @@ get_current_branch() {
         fi
     fi
 
-    echo "main"  # Final fallback
+    # 7. Final fallback
+    echo "main"
 }
 
 # Check if we have git available

--- a/.claude/skills/iikit-bugfix/scripts/bash/common.sh
+++ b/.claude/skills/iikit-bugfix/scripts/bash/common.sh
@@ -154,28 +154,44 @@ get_repo_root() {
 }
 
 # Get current branch, with fallback for non-git repositories
-# Detection cascade: active-feature file > SPECIFY_FEATURE env > git branch > single feature > fallback
+# Detection cascade: SPECIFY_FEATURE env > git feature branch (NNN-*) > active-feature file > git branch (non-feature) > active-feature (non-git) > scan specs dir > fallback
 get_current_branch() {
-    # 1. Check sticky active-feature file (survives restarts)
+    # 1. Check SPECIFY_FEATURE environment variable (explicit CI override)
+    if [[ -n "${SPECIFY_FEATURE:-}" ]]; then
+        echo "$SPECIFY_FEATURE"
+        return
+    fi
+
+    # 2. Check git branch — if it matches a feature pattern (NNN-*), use it
+    #    This ensures switching branches always picks up the correct feature,
+    #    even when a stale active-feature file points elsewhere.
+    local git_branch
+    git_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) && [[ -n "$git_branch" ]] && {
+        if [[ "$git_branch" =~ ^[0-9]{3}- ]]; then
+            echo "$git_branch"
+            return
+        fi
+
+        # 3. On a non-feature branch (e.g. main): fall back to sticky active-feature file
+        local active
+        active=$(read_active_feature 2>/dev/null) && [[ -n "$active" ]] && {
+            echo "$active"
+            return
+        }
+
+        # 4. Non-feature git branch, no sticky file — return branch as-is
+        echo "$git_branch"
+        return
+    }
+
+    # 5. Non-git: check sticky active-feature file
     local active
     active=$(read_active_feature 2>/dev/null) && [[ -n "$active" ]] && {
         echo "$active"
         return
     }
 
-    # 2. Check SPECIFY_FEATURE environment variable (CI/scripts)
-    if [[ -n "${SPECIFY_FEATURE:-}" ]]; then
-        echo "$SPECIFY_FEATURE"
-        return
-    fi
-
-    # 3. Check git branch if available
-    if git rev-parse --abbrev-ref HEAD >/dev/null 2>&1; then
-        git rev-parse --abbrev-ref HEAD
-        return
-    fi
-
-    # 4. For non-git repos, try to find the latest feature directory
+    # 6. For non-git repos, try to find the latest feature directory
     local repo_root=$(get_repo_root)
     local specs_dir="$repo_root/specs"
 
@@ -203,7 +219,8 @@ get_current_branch() {
         fi
     fi
 
-    echo "main"  # Final fallback
+    # 7. Final fallback
+    echo "main"
 }
 
 # Check if we have git available

--- a/.claude/skills/iikit-clarify/scripts/bash/common.sh
+++ b/.claude/skills/iikit-clarify/scripts/bash/common.sh
@@ -154,28 +154,44 @@ get_repo_root() {
 }
 
 # Get current branch, with fallback for non-git repositories
-# Detection cascade: active-feature file > SPECIFY_FEATURE env > git branch > single feature > fallback
+# Detection cascade: SPECIFY_FEATURE env > git feature branch (NNN-*) > active-feature file > git branch (non-feature) > active-feature (non-git) > scan specs dir > fallback
 get_current_branch() {
-    # 1. Check sticky active-feature file (survives restarts)
+    # 1. Check SPECIFY_FEATURE environment variable (explicit CI override)
+    if [[ -n "${SPECIFY_FEATURE:-}" ]]; then
+        echo "$SPECIFY_FEATURE"
+        return
+    fi
+
+    # 2. Check git branch — if it matches a feature pattern (NNN-*), use it
+    #    This ensures switching branches always picks up the correct feature,
+    #    even when a stale active-feature file points elsewhere.
+    local git_branch
+    git_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) && [[ -n "$git_branch" ]] && {
+        if [[ "$git_branch" =~ ^[0-9]{3}- ]]; then
+            echo "$git_branch"
+            return
+        fi
+
+        # 3. On a non-feature branch (e.g. main): fall back to sticky active-feature file
+        local active
+        active=$(read_active_feature 2>/dev/null) && [[ -n "$active" ]] && {
+            echo "$active"
+            return
+        }
+
+        # 4. Non-feature git branch, no sticky file — return branch as-is
+        echo "$git_branch"
+        return
+    }
+
+    # 5. Non-git: check sticky active-feature file
     local active
     active=$(read_active_feature 2>/dev/null) && [[ -n "$active" ]] && {
         echo "$active"
         return
     }
 
-    # 2. Check SPECIFY_FEATURE environment variable (CI/scripts)
-    if [[ -n "${SPECIFY_FEATURE:-}" ]]; then
-        echo "$SPECIFY_FEATURE"
-        return
-    fi
-
-    # 3. Check git branch if available
-    if git rev-parse --abbrev-ref HEAD >/dev/null 2>&1; then
-        git rev-parse --abbrev-ref HEAD
-        return
-    fi
-
-    # 4. For non-git repos, try to find the latest feature directory
+    # 6. For non-git repos, try to find the latest feature directory
     local repo_root=$(get_repo_root)
     local specs_dir="$repo_root/specs"
 
@@ -203,7 +219,8 @@ get_current_branch() {
         fi
     fi
 
-    echo "main"  # Final fallback
+    # 7. Final fallback
+    echo "main"
 }
 
 # Check if we have git available

--- a/.claude/skills/iikit-core/scripts/bash/common.sh
+++ b/.claude/skills/iikit-core/scripts/bash/common.sh
@@ -154,28 +154,39 @@ get_repo_root() {
 }
 
 # Get current branch, with fallback for non-git repositories
-# Detection cascade: active-feature file > SPECIFY_FEATURE env > git branch > single feature > fallback
+# Detection cascade: SPECIFY_FEATURE env > git feature branch (NNN-*) > active-feature file > git branch (non-feature) > scan specs dir > fallback
 get_current_branch() {
-    # 1. Check sticky active-feature file (survives restarts)
-    local active
-    active=$(read_active_feature 2>/dev/null) && [[ -n "$active" ]] && {
-        echo "$active"
-        return
-    }
-
-    # 2. Check SPECIFY_FEATURE environment variable (CI/scripts)
+    # 1. Check SPECIFY_FEATURE environment variable (explicit CI override)
     if [[ -n "${SPECIFY_FEATURE:-}" ]]; then
         echo "$SPECIFY_FEATURE"
         return
     fi
 
-    # 3. Check git branch if available
+    # 2. Check git branch — if it matches a feature pattern (NNN-*), use it
+    #    This ensures switching branches always picks up the correct feature,
+    #    even when a stale active-feature file points elsewhere.
     if git rev-parse --abbrev-ref HEAD >/dev/null 2>&1; then
-        git rev-parse --abbrev-ref HEAD
+        local git_branch
+        git_branch=$(git rev-parse --abbrev-ref HEAD)
+
+        if [[ "$git_branch" =~ ^[0-9]{3}- ]]; then
+            echo "$git_branch"
+            return
+        fi
+
+        # 3. On a non-feature branch (e.g. main): fall back to sticky active-feature file
+        local active
+        active=$(read_active_feature 2>/dev/null) && [[ -n "$active" ]] && {
+            echo "$active"
+            return
+        }
+
+        # 4. Non-feature git branch, no sticky file — return branch as-is
+        echo "$git_branch"
         return
     fi
 
-    # 4. For non-git repos, try to find the latest feature directory
+    # 5. For non-git repos, try to find the latest feature directory
     local repo_root=$(get_repo_root)
     local specs_dir="$repo_root/specs"
 
@@ -203,7 +214,8 @@ get_current_branch() {
         fi
     fi
 
-    echo "main"  # Final fallback
+    # 6. Final fallback
+    echo "main"
 }
 
 # Check if we have git available

--- a/.claude/skills/iikit-core/scripts/bash/common.sh
+++ b/.claude/skills/iikit-core/scripts/bash/common.sh
@@ -154,7 +154,7 @@ get_repo_root() {
 }
 
 # Get current branch, with fallback for non-git repositories
-# Detection cascade: SPECIFY_FEATURE env > git feature branch (NNN-*) > active-feature file > git branch (non-feature) > scan specs dir > fallback
+# Detection cascade: SPECIFY_FEATURE env > git feature branch (NNN-*) > active-feature file > git branch (non-feature) > active-feature (non-git) > scan specs dir > fallback
 get_current_branch() {
     # 1. Check SPECIFY_FEATURE environment variable (explicit CI override)
     if [[ -n "${SPECIFY_FEATURE:-}" ]]; then
@@ -165,10 +165,8 @@ get_current_branch() {
     # 2. Check git branch — if it matches a feature pattern (NNN-*), use it
     #    This ensures switching branches always picks up the correct feature,
     #    even when a stale active-feature file points elsewhere.
-    if git rev-parse --abbrev-ref HEAD >/dev/null 2>&1; then
-        local git_branch
-        git_branch=$(git rev-parse --abbrev-ref HEAD)
-
+    local git_branch
+    git_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) && [[ -n "$git_branch" ]] && {
         if [[ "$git_branch" =~ ^[0-9]{3}- ]]; then
             echo "$git_branch"
             return
@@ -184,9 +182,16 @@ get_current_branch() {
         # 4. Non-feature git branch, no sticky file — return branch as-is
         echo "$git_branch"
         return
-    fi
+    }
 
-    # 5. For non-git repos, try to find the latest feature directory
+    # 5. Non-git: check sticky active-feature file
+    local active
+    active=$(read_active_feature 2>/dev/null) && [[ -n "$active" ]] && {
+        echo "$active"
+        return
+    }
+
+    # 6. For non-git repos, try to find the latest feature directory
     local repo_root=$(get_repo_root)
     local specs_dir="$repo_root/specs"
 
@@ -214,7 +219,7 @@ get_current_branch() {
         fi
     fi
 
-    # 6. Final fallback
+    # 7. Final fallback
     echo "main"
 }
 

--- a/tests/bash/common.bats
+++ b/tests/bash/common.bats
@@ -293,12 +293,12 @@ EOF
 # get_current_branch cascade priority tests
 # =============================================================================
 
-@test "get_current_branch: active-feature takes priority over SPECIFY_FEATURE" {
+@test "get_current_branch: SPECIFY_FEATURE takes priority over active-feature" {
     mkdir -p "$TEST_DIR/specs/002-sticky-feature"
     write_active_feature "002-sticky-feature"
     export SPECIFY_FEATURE="001-env-feature"
     result=$(get_current_branch)
-    [[ "$result" == "002-sticky-feature" ]]
+    [[ "$result" == "001-env-feature" ]]
     unset SPECIFY_FEATURE
 }
 

--- a/tests/bash/common.bats
+++ b/tests/bash/common.bats
@@ -310,6 +310,54 @@ EOF
     unset SPECIFY_FEATURE
 }
 
+@test "get_current_branch: git feature branch overrides stale active-feature" {
+    # Simulate switching from 001 to 002: sticky file still says 001
+    mkdir -p "$TEST_DIR/specs/001-old-feature"
+    mkdir -p "$TEST_DIR/specs/002-new-feature"
+    write_active_feature "001-old-feature"
+
+    # Mock git to return a feature branch
+    git() {
+        if [[ "$1" == "rev-parse" && "$2" == "--abbrev-ref" ]]; then
+            echo "002-new-feature"
+            return 0
+        elif [[ "$1" == "rev-parse" && "$2" == "--show-toplevel" ]]; then
+            echo "$TEST_DIR"
+            return 0
+        fi
+        command git "$@"
+    }
+    export -f git
+
+    result=$(get_current_branch)
+    [[ "$result" == "002-new-feature" ]]
+
+    unset -f git
+}
+
+@test "get_current_branch: non-feature branch falls back to active-feature" {
+    mkdir -p "$TEST_DIR/specs/001-my-feature"
+    write_active_feature "001-my-feature"
+
+    # Mock git to return main (non-feature branch)
+    git() {
+        if [[ "$1" == "rev-parse" && "$2" == "--abbrev-ref" ]]; then
+            echo "main"
+            return 0
+        elif [[ "$1" == "rev-parse" && "$2" == "--show-toplevel" ]]; then
+            echo "$TEST_DIR"
+            return 0
+        fi
+        command git "$@"
+    }
+    export -f git
+
+    result=$(get_current_branch)
+    [[ "$result" == "001-my-feature" ]]
+
+    unset -f git
+}
+
 # =============================================================================
 # check_feature_branch exit code 2 tests
 # =============================================================================


### PR DESCRIPTION
## Summary
- Reorder the `get_current_branch()` cascade so git branch takes priority over the sticky `.specify/active-feature` file when on a feature branch (`NNN-*` pattern)
- Fixes wrong feature detection when switching between feature branches (e.g., from `001-xxx` to `002-xxx`)
- The sticky file now only applies when on non-feature branches like `main`

## Test plan
- [ ] On branch `001-feature-a`, verify detection returns `001-feature-a`
- [ ] Switch to branch `002-feature-b`, verify detection returns `002-feature-b` (not stale `001-feature-a`)
- [ ] On `main` with `.specify/active-feature` set, verify sticky file is still used
- [ ] With `SPECIFY_FEATURE` env var set, verify it takes top priority

Closes #44
Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)