### PR TITLE
fix(hooks): check staged files in pre-commit step definitions gate

### DIFF
--- a/.claude/skills/iikit-core/scripts/bash/pre-commit-hook.sh
+++ b/.claude/skills/iikit-core/scripts/bash/pre-commit-hook.sh
@@ -115,8 +115,21 @@ if [[ -n "$STAGED_CODE_FILES" ]]; then
 
         # ── Gate 1: Step definitions directory must exist with at least one file ──
         # Warning only — agent may not have created step_definitions yet
+        # Check both working tree AND staging area (files may be staged but not yet on disk during /iikit-07-implement)
         STEP_DEFS_DIR="$feat_dir/tests/step_definitions"
-        if [[ ! -d "$STEP_DEFS_DIR" ]] || [[ -z "$(ls -A "$STEP_DEFS_DIR" 2>/dev/null)" ]]; then
+        STEP_DEFS_FOUND=false
+        if [[ -d "$STEP_DEFS_DIR" ]] && [[ -n "$(ls -A "$STEP_DEFS_DIR" 2>/dev/null)" ]]; then
+            STEP_DEFS_FOUND=true
+        fi
+        if [[ "$STEP_DEFS_FOUND" == false ]]; then
+            # Check if step definition files are staged in the git index
+            FEAT_REL_PATH="specs/$FEAT_NAME"
+            STAGED_STEP_DEFS=$(git diff --cached --name-only 2>/dev/null | grep "$FEAT_REL_PATH/tests/step_definitions/") || true
+            if [[ -n "$STAGED_STEP_DEFS" ]]; then
+                STEP_DEFS_FOUND=true
+            fi
+        fi
+        if [[ "$STEP_DEFS_FOUND" == false ]]; then
             echo "[iikit] Warning: specs/$FEAT_NAME — missing step definitions" >&2
             echo "[iikit]   Expected: specs/$FEAT_NAME/tests/step_definitions/ with at least one file" >&2
             echo "[iikit]   Run /iikit-07-implement to generate step definitions." >&2

--- a/.claude/skills/iikit-core/scripts/bash/pre-commit-hook.sh
+++ b/.claude/skills/iikit-core/scripts/bash/pre-commit-hook.sh
@@ -122,9 +122,9 @@ if [[ -n "$STAGED_CODE_FILES" ]]; then
             STEP_DEFS_FOUND=true
         fi
         if [[ "$STEP_DEFS_FOUND" == false ]]; then
-            # Check if step definition files are staged in the git index
+            # Check if step definition files are staged in the git index (exclude deletions)
             FEAT_REL_PATH="specs/$FEAT_NAME"
-            STAGED_STEP_DEFS=$(git diff --cached --name-only 2>/dev/null | grep "$FEAT_REL_PATH/tests/step_definitions/") || true
+            STAGED_STEP_DEFS=$(git diff --cached --name-only --diff-filter=ACMR 2>/dev/null | grep -F -- "$FEAT_REL_PATH/tests/step_definitions/") || true
             if [[ -n "$STAGED_STEP_DEFS" ]]; then
                 STEP_DEFS_FOUND=true
             fi


### PR DESCRIPTION
## Summary
- Pre-commit Gate 1 now checks both working tree AND git staging area for step definition files
- Prevents false "missing step definitions" warnings during `/iikit-07-implement` when files are staged but directory doesn't exist on disk yet

## Test plan
- [ ] Stage step definition files without writing to working tree, verify no warning
- [ ] Commit without step definitions present anywhere, verify warning still fires
- [ ] Normal BDD workflow with step definitions on disk, verify no regression

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)