### PR TITLE
feat(agents): add GitHub Copilot support

### DIFF
--- a/.claude/skills/iikit-02-plan/scripts/bash/update-agent-context.sh
+++ b/.claude/skills/iikit-02-plan/scripts/bash/update-agent-context.sh
@@ -233,7 +233,8 @@ update_specific_agent() {
         claude) update_agent_file "$CLAUDE_FILE" "Claude Code" ;;
         gemini) update_agent_file "$GEMINI_FILE" "Gemini CLI" ;;
         copilot) update_agent_file "$AGENTS_FILE" "GitHub Copilot" ;;
-        codex|opencode) update_agent_file "$AGENTS_FILE" "Codex CLI" ;;
+        codex) update_agent_file "$AGENTS_FILE" "Codex CLI" ;;
+        opencode) update_agent_file "$AGENTS_FILE" "OpenCode" ;;
         *)
             log_error "Unknown agent type '$agent_type'"
             log_error "Expected: claude|gemini|copilot|codex|opencode"

--- a/.claude/skills/iikit-02-plan/scripts/bash/update-agent-context.sh
+++ b/.claude/skills/iikit-02-plan/scripts/bash/update-agent-context.sh
@@ -232,6 +232,7 @@ update_specific_agent() {
     case "$agent_type" in
         claude) update_agent_file "$CLAUDE_FILE" "Claude Code" ;;
         gemini) update_agent_file "$GEMINI_FILE" "Gemini CLI" ;;
+        copilot) update_agent_file "$AGENTS_FILE" "GitHub Copilot" ;;
         codex|opencode) update_agent_file "$AGENTS_FILE" "Codex CLI" ;;
         *)
             log_error "Unknown agent type '$agent_type'"

--- a/.claude/skills/iikit-02-plan/scripts/powershell/update-agent-context.ps1
+++ b/.claude/skills/iikit-02-plan/scripts/powershell/update-agent-context.ps1
@@ -293,7 +293,7 @@ function Update-SpecificAgent {
         'claude'   { Update-AgentFile -TargetFile $CLAUDE_FILE   -AgentName 'Claude Code' }
         'gemini'   { Update-AgentFile -TargetFile $GEMINI_FILE   -AgentName 'Gemini CLI' }
         'copilot'  { Update-AgentFile -TargetFile $AGENTS_FILE   -AgentName 'GitHub Copilot' }
-        'opencode' { Update-AgentFile -TargetFile $AGENTS_FILE   -AgentName 'opencode' }
+        'opencode' { Update-AgentFile -TargetFile $AGENTS_FILE   -AgentName 'OpenCode' }
         'codex'    { Update-AgentFile -TargetFile $AGENTS_FILE   -AgentName 'Codex CLI' }
         default { Write-Err "Unknown agent type '$Type'"; Write-Err 'Expected: claude|gemini|copilot|codex|opencode'; return $false }
     }

--- a/.claude/skills/iikit-02-plan/scripts/powershell/update-agent-context.ps1
+++ b/.claude/skills/iikit-02-plan/scripts/powershell/update-agent-context.ps1
@@ -25,7 +25,7 @@ Relies on common helper functions in common.ps1
 #>
 param(
     [Parameter(Position=0)]
-    [ValidateSet('claude','gemini','codex','opencode')]
+    [ValidateSet('claude','gemini','copilot','codex','opencode')]
     [string]$AgentType
 )
 
@@ -292,9 +292,10 @@ function Update-SpecificAgent {
     switch ($Type) {
         'claude'   { Update-AgentFile -TargetFile $CLAUDE_FILE   -AgentName 'Claude Code' }
         'gemini'   { Update-AgentFile -TargetFile $GEMINI_FILE   -AgentName 'Gemini CLI' }
+        'copilot'  { Update-AgentFile -TargetFile $AGENTS_FILE   -AgentName 'GitHub Copilot' }
         'opencode' { Update-AgentFile -TargetFile $AGENTS_FILE   -AgentName 'opencode' }
         'codex'    { Update-AgentFile -TargetFile $AGENTS_FILE   -AgentName 'Codex CLI' }
-        default { Write-Err "Unknown agent type '$Type'"; Write-Err 'Expected: claude|gemini|codex|opencode'; return $false }
+        default { Write-Err "Unknown agent type '$Type'"; Write-Err 'Expected: claude|gemini|copilot|codex|opencode'; return $false }
     }
 }
 

--- a/.claude/skills/iikit-core/scripts/bash/setup-unix-links.sh
+++ b/.claude/skills/iikit-core/scripts/bash/setup-unix-links.sh
@@ -9,6 +9,7 @@
 #   - .opencode/skills -> .claude/skills
 #   - CLAUDE.md -> AGENTS.md
 #   - GEMINI.md -> AGENTS.md
+#   - .github/copilot-instructions.md -> AGENTS.md (GitHub Copilot)
 #
 # USAGE:
 #   ./setup-unix-links.sh           # Create symlinks with prompts
@@ -155,9 +156,21 @@ create_file_link() {
         fi
     fi
 
-    # Create symlink with relative path (files are in same directory)
-    if ln -s "$target_name" "$link_path" 2>/dev/null; then
-        echo -e "  ${GREEN}[OK] $link_name -> $target_name (symlink)${NC}"
+    # Ensure parent directory exists
+    local parent_dir
+    parent_dir=$(dirname "$link_path")
+    if [[ ! -d "$parent_dir" ]]; then
+        mkdir -p "$parent_dir"
+    fi
+
+    # Create symlink with relative path
+    local relative_target
+    relative_target=$(realpath --relative-to="$parent_dir" "$target_path" 2>/dev/null || \
+                      python3 -c "import os.path; print(os.path.relpath('$target_path', '$parent_dir'))" 2>/dev/null || \
+                      echo "$target_name")
+
+    if ln -s "$relative_target" "$link_path" 2>/dev/null; then
+        echo -e "  ${GREEN}[OK] $link_name -> $relative_target (symlink)${NC}"
         return 0
     else
         echo -e "  ${RED}[ERROR] Failed to create symlink: $link_name${NC}"
@@ -191,6 +204,7 @@ echo -e "${WHITE}Creating file links...${NC}"
 declare -a FILE_LINKS=(
     "CLAUDE.md:AGENTS.md"
     "GEMINI.md:AGENTS.md"
+    ".github/copilot-instructions.md:AGENTS.md"
 )
 
 for link_spec in "${FILE_LINKS[@]}"; do

--- a/.claude/skills/iikit-core/scripts/bash/setup-unix-links.sh
+++ b/.claude/skills/iikit-core/scripts/bash/setup-unix-links.sh
@@ -167,7 +167,7 @@ create_file_link() {
     local relative_target
     relative_target=$(realpath --relative-to="$parent_dir" "$target_path" 2>/dev/null || \
                       python3 -c "import os.path; print(os.path.relpath('$target_path', '$parent_dir'))" 2>/dev/null || \
-                      echo "$target_name")
+                      echo "$target_path")
 
     if ln -s "$relative_target" "$link_path" 2>/dev/null; then
         echo -e "  ${GREEN}[OK] $link_name -> $relative_target (symlink)${NC}"

--- a/.claude/skills/iikit-core/scripts/bash/update-agent-context.sh
+++ b/.claude/skills/iikit-core/scripts/bash/update-agent-context.sh
@@ -233,7 +233,8 @@ update_specific_agent() {
         claude) update_agent_file "$CLAUDE_FILE" "Claude Code" ;;
         gemini) update_agent_file "$GEMINI_FILE" "Gemini CLI" ;;
         copilot) update_agent_file "$AGENTS_FILE" "GitHub Copilot" ;;
-        codex|opencode) update_agent_file "$AGENTS_FILE" "Codex CLI" ;;
+        codex) update_agent_file "$AGENTS_FILE" "Codex CLI" ;;
+        opencode) update_agent_file "$AGENTS_FILE" "OpenCode" ;;
         *)
             log_error "Unknown agent type '$agent_type'"
             log_error "Expected: claude|gemini|copilot|codex|opencode"

--- a/.claude/skills/iikit-core/scripts/bash/update-agent-context.sh
+++ b/.claude/skills/iikit-core/scripts/bash/update-agent-context.sh
@@ -232,6 +232,7 @@ update_specific_agent() {
     case "$agent_type" in
         claude) update_agent_file "$CLAUDE_FILE" "Claude Code" ;;
         gemini) update_agent_file "$GEMINI_FILE" "Gemini CLI" ;;
+        copilot) update_agent_file "$AGENTS_FILE" "GitHub Copilot" ;;
         codex|opencode) update_agent_file "$AGENTS_FILE" "Codex CLI" ;;
         *)
             log_error "Unknown agent type '$agent_type'"

--- a/.claude/skills/iikit-core/scripts/powershell/setup-windows-links.ps1
+++ b/.claude/skills/iikit-core/scripts/powershell/setup-windows-links.ps1
@@ -9,6 +9,7 @@
     - .opencode/skills -> .claude/skills
     - CLAUDE.md -> AGENTS.md
     - GEMINI.md -> AGENTS.md
+    - .github/copilot-instructions.md -> AGENTS.md (GitHub Copilot)
 
     On Windows, symlinks require either:
     - Administrator privileges, OR
@@ -181,6 +182,12 @@ function New-FileLink {
         }
     }
 
+    # Ensure parent directory exists
+    $parentDir = Split-Path $LinkPath -Parent
+    if (-not (Test-Path $parentDir)) {
+        New-Item -ItemType Directory -Path $parentDir -Force | Out-Null
+    }
+
     if ($CanSymlink) {
         try {
             New-Item -ItemType SymbolicLink -Path $LinkPath -Target $TargetPath -ErrorAction Stop | Out-Null
@@ -246,7 +253,8 @@ Write-Host "Creating file links..." -ForegroundColor White
 
 $fileLinks = @(
     @{ Link = "CLAUDE.md"; Target = "AGENTS.md" },
-    @{ Link = "GEMINI.md"; Target = "AGENTS.md" }
+    @{ Link = "GEMINI.md"; Target = "AGENTS.md" },
+    @{ Link = ".github\copilot-instructions.md"; Target = "AGENTS.md" }
 )
 
 foreach ($link in $fileLinks) {

--- a/.claude/skills/iikit-core/scripts/powershell/setup-windows-links.ps1
+++ b/.claude/skills/iikit-core/scripts/powershell/setup-windows-links.ps1
@@ -119,7 +119,7 @@ function New-DirectoryLink {
 
     # Ensure parent directory exists
     $parentDir = Split-Path $LinkPath -Parent
-    if (-not (Test-Path $parentDir)) {
+    if (-not [string]::IsNullOrWhiteSpace($parentDir) -and -not (Test-Path $parentDir)) {
         New-Item -ItemType Directory -Path $parentDir -Force | Out-Null
     }
 
@@ -184,7 +184,7 @@ function New-FileLink {
 
     # Ensure parent directory exists
     $parentDir = Split-Path $LinkPath -Parent
-    if (-not (Test-Path $parentDir)) {
+    if (-not [string]::IsNullOrWhiteSpace($parentDir) -and -not (Test-Path $parentDir)) {
         New-Item -ItemType Directory -Path $parentDir -Force | Out-Null
     }
 

--- a/.claude/skills/iikit-core/scripts/powershell/update-agent-context.ps1
+++ b/.claude/skills/iikit-core/scripts/powershell/update-agent-context.ps1
@@ -293,7 +293,7 @@ function Update-SpecificAgent {
         'claude'   { Update-AgentFile -TargetFile $CLAUDE_FILE   -AgentName 'Claude Code' }
         'gemini'   { Update-AgentFile -TargetFile $GEMINI_FILE   -AgentName 'Gemini CLI' }
         'copilot'  { Update-AgentFile -TargetFile $AGENTS_FILE   -AgentName 'GitHub Copilot' }
-        'opencode' { Update-AgentFile -TargetFile $AGENTS_FILE   -AgentName 'opencode' }
+        'opencode' { Update-AgentFile -TargetFile $AGENTS_FILE   -AgentName 'OpenCode' }
         'codex'    { Update-AgentFile -TargetFile $AGENTS_FILE   -AgentName 'Codex CLI' }
         default { Write-Err "Unknown agent type '$Type'"; Write-Err 'Expected: claude|gemini|copilot|codex|opencode'; return $false }
     }

--- a/.claude/skills/iikit-core/scripts/powershell/update-agent-context.ps1
+++ b/.claude/skills/iikit-core/scripts/powershell/update-agent-context.ps1
@@ -25,7 +25,7 @@ Relies on common helper functions in common.ps1
 #>
 param(
     [Parameter(Position=0)]
-    [ValidateSet('claude','gemini','codex','opencode')]
+    [ValidateSet('claude','gemini','copilot','codex','opencode')]
     [string]$AgentType
 )
 
@@ -292,9 +292,10 @@ function Update-SpecificAgent {
     switch ($Type) {
         'claude'   { Update-AgentFile -TargetFile $CLAUDE_FILE   -AgentName 'Claude Code' }
         'gemini'   { Update-AgentFile -TargetFile $GEMINI_FILE   -AgentName 'Gemini CLI' }
+        'copilot'  { Update-AgentFile -TargetFile $AGENTS_FILE   -AgentName 'GitHub Copilot' }
         'opencode' { Update-AgentFile -TargetFile $AGENTS_FILE   -AgentName 'opencode' }
         'codex'    { Update-AgentFile -TargetFile $AGENTS_FILE   -AgentName 'Codex CLI' }
-        default { Write-Err "Unknown agent type '$Type'"; Write-Err 'Expected: claude|gemini|codex|opencode'; return $false }
+        default { Write-Err "Unknown agent type '$Type'"; Write-Err 'Expected: claude|gemini|copilot|codex|opencode'; return $false }
     }
 }
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+../AGENTS.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-Intent Integrity Kit (IIKit) preserves your intent from idea to implementation through specification-driven development with cryptographic verification. Compatible with Claude Code, Codex, Gemini, and OpenCode.
+Intent Integrity Kit (IIKit) preserves your intent from idea to implementation through specification-driven development with cryptographic verification. Compatible with Claude Code, Codex, Gemini, OpenCode, and GitHub Copilot.
 
 ## Intent Integrity Kit Workflow
 
@@ -43,6 +43,7 @@ Read `FRAMEWORK-PRINCIPLES.md` for this framework's development principles.
 .codex/skills/               # Symlink -> .claude/skills
 .gemini/skills/              # Symlink -> .claude/skills
 .opencode/skills/            # Symlink -> .claude/skills
+.github/copilot-instructions.md  # Symlink -> AGENTS.md (GitHub Copilot)
 
 CONSTITUTION.md              # Project governance (content-agnostic, lives at root)
 PREMISE.md                   # App-wide context: what, who, why, domain, scope
@@ -155,7 +156,7 @@ Skills are stored in `.claude/skills/` with symlinks for other agents:
 - `.gemini/skills/` → `.claude/skills/`
 - `.opencode/skills/` → `.claude/skills/`
 
-Instruction files: `CLAUDE.md` and `GEMINI.md` are symlinks to this file (`AGENTS.md`).
+Instruction files: `CLAUDE.md`, `GEMINI.md`, and `.github/copilot-instructions.md` are symlinks to this file (`AGENTS.md`).
 
 <!-- IIKIT-TECH-START -->
 <!-- Tech stack will be inserted here by /iikit-02-plan -->

--- a/tiles/intent-integrity-kit/README.md
+++ b/tiles/intent-integrity-kit/README.md
@@ -4,7 +4,7 @@
 
 **Closing the intent-to-code chasm**
 
-An AI coding assistant toolkit that preserves your intent from idea to implementation, with cryptographic verification at each step. Compatible with Claude Code, OpenAI Codex, Google Gemini, and OpenCode.
+An AI coding assistant toolkit that preserves your intent from idea to implementation, with cryptographic verification at each step. Compatible with Claude Code, OpenAI Codex, Google Gemini, OpenCode, and GitHub Copilot.
 
 ## What's New in v2.9.0
 
@@ -58,7 +58,7 @@ tessl install tessl-labs/intent-integrity-kit
 
 ```bash
 # 1. Launch your AI assistant
-claude          # or: codex, gemini, opencode
+claude          # or: codex, gemini, opencode, copilot
 
 # 2. Initialize the project
 /iikit-core init
@@ -255,6 +255,7 @@ your-project/
 | OpenAI Codex | `AGENTS.md` |
 | Google Gemini | `GEMINI.md` -> `AGENTS.md` |
 | OpenCode | `AGENTS.md` |
+| GitHub Copilot | `.github/copilot-instructions.md` -> `AGENTS.md` |
 
 ## Acknowledgments
 

--- a/tiles/intent-integrity-kit/tile.json
+++ b/tiles/intent-integrity-kit/tile.json
@@ -2,7 +2,7 @@
   "name": "tessl-labs/intent-integrity-kit",
   "version": "2.9.8",
   "summary": "Closing the intent-to-code chasm - specification-driven development with BDD verification chain",
-  "description": "Intent Integrity Kit (IIKit) preserves your intent from idea to implementation through specification-driven development with BDD verification chain. Compatible with Claude Code, Codex, Gemini, and OpenCode.\n\nWhat's new in v2.9.0: Implementation commit strategy choice (per-task or batch) — batch commits cut implementation time by ~47%. Unified post-phase.sh reduces 3 tool calls to 1 per phase (commit + dashboard + next-step), saving ~26% on per-task runs. Removed redundant dashboard generation from check-prerequisites.sh.",
+  "description": "Intent Integrity Kit (IIKit) preserves your intent from idea to implementation through specification-driven development with BDD verification chain. Compatible with Claude Code, Codex, Gemini, OpenCode, and GitHub Copilot.\n\nWhat's new in v2.9.0: Implementation commit strategy choice (per-task or batch) — batch commits cut implementation time by ~47%. Unified post-phase.sh reduces 3 tool calls to 1 per phase (commit + dashboard + next-step), saving ~26% on per-task runs. Removed redundant dashboard generation from check-prerequisites.sh.",
   "entrypoint": "README.md",
   "private": false,
   "repository": "https://github.com/intent-integrity-chain/kit",


### PR DESCRIPTION
## Summary
- Add `.github/copilot-instructions.md` symlink → `AGENTS.md` (Copilot's standard instructions file)
- Update `setup-unix-links.sh` with cross-directory symlink support for subdirectory targets
- Update `setup-windows-links.ps1` with Copilot link creation
- Add `copilot` case to `update-agent-context.sh` and `.ps1`
- Update AGENTS.md, tile README, and tile.json to list Copilot as supported agent

## Test plan
- [ ] Verify `.github/copilot-instructions.md` symlink resolves to AGENTS.md content
- [ ] Run `setup-unix-links.sh` and verify Copilot link is created
- [ ] Run `update-agent-context.sh copilot` and verify it succeeds
- [ ] Verify GitHub Copilot can read project instructions from the file

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)