### PR TITLE
feat(integrity): add assertion integrity enforcement layers

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,6 +11,18 @@
           }
         ]
       }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/skills/iikit-core/scripts/bash/check-hook-bypass.sh",
+            "timeout": 5
+          }
+        ]
+      }
     ]
   }
 }

--- a/.claude/skills/iikit-core/references/ci-assertion-verification.md
+++ b/.claude/skills/iikit-core/references/ci-assertion-verification.md
@@ -1,0 +1,48 @@
+# CI Assertion Integrity Verification
+
+Server-side enforcement that cannot be bypassed by `--no-verify`.
+
+## Why
+
+The pre-commit hook validates assertion integrity client-side, but any agent with shell access can bypass it using `git commit --no-verify`. CI verification is the only enforcement that works regardless of which agent, tool, or human made the commit.
+
+## GitHub Actions
+
+Add this step to your PR workflow:
+
+```yaml
+- name: Verify assertion integrity
+  run: bash .claude/skills/iikit-core/scripts/bash/verify-assertion-integrity.sh
+```
+
+Or with JSON output for programmatic consumption:
+
+```yaml
+- name: Verify assertion integrity
+  run: |
+    result=$(bash .claude/skills/iikit-core/scripts/bash/verify-assertion-integrity.sh --json)
+    echo "$result"
+    echo "$result" | jq -e '.status == "pass"'
+```
+
+## GitLab CI
+
+```yaml
+verify-assertions:
+  script:
+    - bash .claude/skills/iikit-core/scripts/bash/verify-assertion-integrity.sh
+```
+
+## Any CI
+
+```bash
+bash .claude/skills/iikit-core/scripts/bash/verify-assertion-integrity.sh
+# Exit code 0 = pass, 1 = fail, 2 = missing dependencies
+```
+
+## What It Checks
+
+- Scans all features in `specs/*/tests/features/`
+- Computes SHA-256 hash of Gherkin assertion lines (Given/When/Then/And/But)
+- Compares against stored hash in `specs/*/context.json`
+- Fails if any hash mismatches (assertions modified without `/iikit-04-testify`)

--- a/.claude/skills/iikit-core/scripts/bash/check-hook-bypass.sh
+++ b/.claude/skills/iikit-core/scripts/bash/check-hook-bypass.sh
@@ -3,11 +3,16 @@
 # Exit 2 with stderr message = block the tool call.
 # Exit 0 = allow (no opinion).
 
-set -euo pipefail
+set -uo pipefail
+
+# If jq is not available, allow the call (don't block all Bash calls)
+if ! command -v jq >/dev/null 2>&1; then
+    exit 0
+fi
 
 INPUT=$(cat)
-TOOL=$(echo "$INPUT" | jq -r '.tool_name // empty')
-COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+TOOL=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null) || exit 0
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null) || exit 0
 
 if [[ "$TOOL" != "Bash" ]] || [[ -z "$COMMAND" ]]; then
     exit 0

--- a/.claude/skills/iikit-core/scripts/bash/check-hook-bypass.sh
+++ b/.claude/skills/iikit-core/scripts/bash/check-hook-bypass.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# PreToolUse hook: block git commit --no-verify and other hook bypass attempts.
+# Returns JSON with permissionDecision: "deny" when bypass is detected.
+# Exit 0 = decision provided; the harness evaluates the JSON.
+
+INPUT=$(cat)
+TOOL=$(echo "$INPUT" | jq -r '.tool_name // empty')
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+if [[ "$TOOL" != "Bash" ]] || [[ -z "$COMMAND" ]]; then
+    exit 0
+fi
+
+# Check for --no-verify or -n flag on git commit
+# Strip quoted message content (-m "..." or heredoc) before checking flags
+# to avoid false positives when the commit message mentions --no-verify
+if echo "$COMMAND" | grep -qE '\bgit\s+commit\b'; then
+    # Extract just the git commit invocation line, strip -m message content
+    GIT_ARGS=$(echo "$COMMAND" | head -1 | sed 's/-m "[^"]*"//g' | sed "s/-m '[^']*'//g")
+    if echo "$GIT_ARGS" | grep -qE '(--no-verify|\s-[a-zA-Z]*n\b)'; then
+        echo '{"decision":"block","reason":"git commit --no-verify is prohibited. Fix the pre-commit hook failure instead of bypassing it. Re-run /iikit-04-testify if assertion hashes are stale."}'
+        exit 2
+    fi
+fi
+
+# Check for hook file deletion/modification
+if echo "$COMMAND" | grep -qE '(rm|mv|chmod|truncate|>)\s+.*\.git/hooks/'; then
+    echo '{"decision":"block","reason":"Modifying .git/hooks/ is prohibited. Pre-commit hooks are an integrity gate."}'
+    exit 2
+fi
+
+# Check for git plumbing bypass
+if echo "$COMMAND" | grep -qE '\bgit\s+(commit-tree|mktree|hash-object\s+.*-w)\b'; then
+    echo '{"decision":"block","reason":"Git plumbing commands that bypass hooks are prohibited."}'
+    exit 2
+fi
+
+exit 0

--- a/.claude/skills/iikit-core/scripts/bash/check-hook-bypass.sh
+++ b/.claude/skills/iikit-core/scripts/bash/check-hook-bypass.sh
@@ -1,7 +1,9 @@
-#!/bin/bash
-# PreToolUse hook: block git commit --no-verify and other hook bypass attempts.
-# Returns JSON with permissionDecision: "deny" when bypass is detected.
-# Exit 0 = decision provided; the harness evaluates the JSON.
+#!/usr/bin/env bash
+# PreToolUse hook: block git commit hook bypass attempts.
+# Exit 2 with stderr message = block the tool call.
+# Exit 0 = allow (no opinion).
+
+set -euo pipefail
 
 INPUT=$(cat)
 TOOL=$(echo "$INPUT" | jq -r '.tool_name // empty')
@@ -12,26 +14,25 @@ if [[ "$TOOL" != "Bash" ]] || [[ -z "$COMMAND" ]]; then
 fi
 
 # Check for --no-verify or -n flag on git commit
-# Strip quoted message content (-m "..." or heredoc) before checking flags
-# to avoid false positives when the commit message mentions --no-verify
-if echo "$COMMAND" | grep -qE '\bgit\s+commit\b'; then
-    # Extract just the git commit invocation line, strip -m message content
+# Extract first line only (avoids matching inside heredoc commit messages)
+# Strip -m "..." content to avoid false positives on message text
+if echo "$COMMAND" | grep -qE 'git[[:space:]]+commit'; then
     GIT_ARGS=$(echo "$COMMAND" | head -1 | sed 's/-m "[^"]*"//g' | sed "s/-m '[^']*'//g")
-    if echo "$GIT_ARGS" | grep -qE '(--no-verify|\s-[a-zA-Z]*n\b)'; then
-        echo '{"decision":"block","reason":"git commit --no-verify is prohibited. Fix the pre-commit hook failure instead of bypassing it. Re-run /iikit-04-testify if assertion hashes are stale."}'
+    if echo "$GIT_ARGS" | grep -qE '(--no-verify|[[:space:]]-[a-zA-Z]*n([[:space:]]|$))'; then
+        echo "git commit with hook bypass is prohibited. Fix the pre-commit hook failure instead. Re-run /iikit-04-testify if assertion hashes are stale." >&2
         exit 2
     fi
 fi
 
 # Check for hook file deletion/modification
-if echo "$COMMAND" | grep -qE '(rm|mv|chmod|truncate|>)\s+.*\.git/hooks/'; then
-    echo '{"decision":"block","reason":"Modifying .git/hooks/ is prohibited. Pre-commit hooks are an integrity gate."}'
+if echo "$COMMAND" | grep -qE '(rm|mv|chmod|truncate|>)[[:space:]].*\.git/hooks'; then
+    echo "Modifying .git/hooks is prohibited. Pre-commit hooks are an integrity gate." >&2
     exit 2
 fi
 
 # Check for git plumbing bypass
-if echo "$COMMAND" | grep -qE '\bgit\s+(commit-tree|mktree|hash-object\s+.*-w)\b'; then
-    echo '{"decision":"block","reason":"Git plumbing commands that bypass hooks are prohibited."}'
+if echo "$COMMAND" | grep -qE 'git[[:space:]]+(commit-tree|mktree|hash-object[[:space:]].*-w)'; then
+    echo "Git plumbing commands that bypass hooks are prohibited." >&2
     exit 2
 fi
 

--- a/.claude/skills/iikit-core/scripts/bash/pre-commit-hook.sh
+++ b/.claude/skills/iikit-core/scripts/bash/pre-commit-hook.sh
@@ -179,7 +179,7 @@ if [[ -n "$STAGED_CODE_FILES" ]]; then
         done
         echo "" >&2
         echo "[iikit] .feature files exist — code commits require proper BDD wiring." >&2
-        echo "[iikit] To bypass (NOT recommended): git commit --no-verify" >&2
+        echo "[iikit] Fix the BDD setup before committing. Do NOT use --no-verify." >&2
         echo "" >&2
         exit 1
     fi
@@ -452,7 +452,7 @@ if [[ "$BLOCKED" == true ]]; then
     done
     echo "" >&2
     echo "[iikit] To fix: Re-run /iikit-04-testify to regenerate test specs with valid hashes." >&2
-    echo "[iikit] To bypass (NOT recommended): git commit --no-verify" >&2
+    echo "[iikit] Do NOT use --no-verify to bypass this check." >&2
     echo "" >&2
     exit 1
 fi

--- a/.claude/skills/iikit-core/scripts/bash/verify-assertion-integrity.sh
+++ b/.claude/skills/iikit-core/scripts/bash/verify-assertion-integrity.sh
@@ -3,26 +3,22 @@
 #
 # Verifies that .feature file assertion hashes match stored hashes in context.json.
 # Designed to run in any CI system (GitHub Actions, GitLab CI, Jenkins, etc.)
-# as a server-side enforcement layer that cannot be bypassed by --no-verify.
+# as a server-side enforcement layer that cannot be bypassed client-side.
 #
 # Usage:
 #   ./verify-assertion-integrity.sh [--json] [--project-root PATH]
 #
 # Exit codes:
 #   0 — All assertions verified (or no assertions found)
-#   1 — Assertion integrity check failed (hash mismatch)
-#   2 — Missing dependencies (jq, shasum)
+#   1 — Assertion integrity check failed (hash mismatch or missing hash)
+#   2 — Missing dependencies (jq, shasum/sha256sum)
 #
-# Requires: bash 3.2+, jq, shasum
+# Requires: bash 3.2+, jq, shasum or sha256sum
 
 set -euo pipefail
 
-# Source shared functions by calling testify-tdd.sh compute-hash to verify it works,
-# then define the functions we need by extracting them from the script.
+# Extract function definitions from testify-tdd.sh without executing it.
 SCRIPT_DIR="$(CDPATH="" cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-
-# extract_assertions and compute_assertion_hash are defined in testify-tdd.sh.
-# We source the function definitions by evaluating only the function blocks.
 eval "$(sed -n '/^extract_assertions()/,/^}/p' "$SCRIPT_DIR/testify-tdd.sh")"
 eval "$(sed -n '/^compute_assertion_hash()/,/^}/p' "$SCRIPT_DIR/testify-tdd.sh")"
 
@@ -42,7 +38,7 @@ while [[ $# -gt 0 ]]; do
 Usage: verify-assertion-integrity.sh [--json] [--project-root PATH]
 
 Verifies .feature file assertion hashes against stored hashes in context.json.
-Server-side enforcement that cannot be bypassed by --no-verify.
+Server-side enforcement that cannot be bypassed client-side.
 
 Options:
   --json              Output results in JSON format
@@ -64,12 +60,16 @@ done
 # DEPENDENCY CHECK
 # =============================================================================
 
-for cmd in jq shasum; do
-    if ! command -v "$cmd" >/dev/null 2>&1; then
-        echo "ERROR: Required command '$cmd' not found" >&2
-        exit 2
-    fi
-done
+if ! command -v jq >/dev/null 2>&1; then
+    echo "ERROR: Required command 'jq' not found" >&2
+    exit 2
+fi
+
+# Support both shasum (macOS) and sha256sum (Linux)
+if ! command -v shasum >/dev/null 2>&1 && ! command -v sha256sum >/dev/null 2>&1; then
+    echo "ERROR: Neither 'shasum' nor 'sha256sum' found" >&2
+    exit 2
+fi
 
 # =============================================================================
 # PROJECT ROOT DETECTION
@@ -130,22 +130,26 @@ for feat_dir in "$SPECS_DIR"/*/; do
     fi
 
     # Read stored hash from context.json
+    # Missing context.json with existing .feature files = integrity failure
+    # (prevents bypass via context.json deletion)
     if [[ ! -f "$CONTEXT_FILE" ]]; then
-        TOTAL_SKIPPED=$((TOTAL_SKIPPED + 1))
+        TOTAL_FAILED=$((TOTAL_FAILED + 1))
+        FAILURES+=("$feat_name: context.json missing (assertions exist but no stored hash)")
         continue
     fi
 
     CONTEXT_JSON=$(cat "$CONTEXT_FILE" 2>/dev/null)
     if ! echo "$CONTEXT_JSON" | jq empty 2>/dev/null; then
-        TOTAL_SKIPPED=$((TOTAL_SKIPPED + 1))
+        TOTAL_FAILED=$((TOTAL_FAILED + 1))
+        FAILURES+=("$feat_name: context.json is invalid JSON")
         continue
     fi
 
     STORED_HASH=$(echo "$CONTEXT_JSON" | jq -r '.testify.assertion_hash // ""' 2>/dev/null || echo "")
-    STORED_DIR=$(echo "$CONTEXT_JSON" | jq -r '.testify.features_dir // ""' 2>/dev/null || echo "")
 
-    if [[ -z "$STORED_HASH" ]] || [[ -z "$STORED_DIR" ]]; then
-        TOTAL_SKIPPED=$((TOTAL_SKIPPED + 1))
+    if [[ -z "$STORED_HASH" ]]; then
+        TOTAL_FAILED=$((TOTAL_FAILED + 1))
+        FAILURES+=("$feat_name: no assertion hash in context.json (run /iikit-04-testify)")
         continue
     fi
 
@@ -154,7 +158,7 @@ for feat_dir in "$SPECS_DIR"/*/; do
         TOTAL_PASSED=$((TOTAL_PASSED + 1))
     else
         TOTAL_FAILED=$((TOTAL_FAILED + 1))
-        FAILURES+=("$feat_name: expected=$STORED_HASH actual=$CURRENT_HASH")
+        FAILURES+=("$feat_name: hash mismatch (stored=$STORED_HASH actual=$CURRENT_HASH)")
     fi
 done
 
@@ -166,14 +170,21 @@ if $JSON_MODE; then
     STATUS="pass"
     [[ "$TOTAL_FAILED" -gt 0 ]] && STATUS="fail"
 
-    FAILURES_JSON="[]"
+    # Build failures array with proper JSON escaping
     if [[ ${#FAILURES[@]} -gt 0 ]]; then
-        FAILURES_JSON=$(printf '"%s",' "${FAILURES[@]}")
-        FAILURES_JSON="[${FAILURES_JSON%,}]"
+        FAILURES_JSON=$(printf '%s\n' "${FAILURES[@]}" | jq -R . | jq -s .)
+    else
+        FAILURES_JSON="[]"
     fi
 
-    printf '{"status":"%s","features_checked":%d,"passed":%d,"failed":%d,"skipped":%d,"failures":%s}\n' \
-        "$STATUS" "$TOTAL_CHECKED" "$TOTAL_PASSED" "$TOTAL_FAILED" "$TOTAL_SKIPPED" "$FAILURES_JSON"
+    jq -n \
+        --arg status "$STATUS" \
+        --argjson checked "$TOTAL_CHECKED" \
+        --argjson passed "$TOTAL_PASSED" \
+        --argjson failed "$TOTAL_FAILED" \
+        --argjson skipped "$TOTAL_SKIPPED" \
+        --argjson failures "$FAILURES_JSON" \
+        '{status:$status,features_checked:$checked,passed:$passed,failed:$failed,skipped:$skipped,failures:$failures}'
 else
     if [[ "$TOTAL_CHECKED" -eq 0 ]]; then
         echo "[iikit] No features with .feature files found — nothing to verify."
@@ -196,7 +207,7 @@ else
         done
         echo ""
         echo "  .feature assertions were modified without re-running /iikit-04-testify."
-        echo "  This may indicate a --no-verify bypass of the pre-commit hook."
+        echo "  This may indicate a hook bypass."
         echo ""
     fi
 fi

--- a/.claude/skills/iikit-core/scripts/bash/verify-assertion-integrity.sh
+++ b/.claude/skills/iikit-core/scripts/bash/verify-assertion-integrity.sh
@@ -19,7 +19,31 @@ set -euo pipefail
 
 # Extract function definitions from testify-tdd.sh without executing it.
 SCRIPT_DIR="$(CDPATH="" cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-eval "$(sed -n '/^extract_assertions()/,/^}/p' "$SCRIPT_DIR/testify-tdd.sh")"
+
+# Override extract_assertions with POSIX-compatible patterns (\s -> [[:space:]])
+# to ensure correct behavior on all grep implementations.
+extract_assertions() {
+    local input_path="$1"
+    if [[ -d "$input_path" ]]; then
+        local files
+        files=$(ls -1 "$input_path"/*.feature 2>/dev/null | LC_ALL=C sort)
+        [[ -z "$files" ]] && { echo ""; return 0; }
+        local f
+        for f in $files; do
+            { grep -E "^[[:space:]]*(Given|When|Then|And|But) " "$f" 2>/dev/null || true; }
+        done | sed 's/^[[:space:]]*//' | sed 's/[[:space:]][[:space:]]*/ /g' | sed 's/[[:space:]]*$//'
+    elif [[ -f "$input_path" ]]; then
+        if [[ "$input_path" == *.feature ]]; then
+            { grep -E "^[[:space:]]*(Given|When|Then|And|But) " "$input_path" 2>/dev/null || true; } \
+                | sed 's/^[[:space:]]*//' | sed 's/[[:space:]][[:space:]]*/ /g' | sed 's/[[:space:]]*$//'
+        else
+            { grep -E "^\*\*(Given|When|Then)\*\*:" "$input_path" 2>/dev/null || true; } \
+                | sed 's/[[:space:]]*$//' | LC_ALL=C sort
+        fi
+    else
+        echo ""; return 0
+    fi
+}
 
 # compute_assertion_hash from testify-tdd.sh uses shasum -a 256.
 # Override to support sha256sum (Linux) when shasum is not available.

--- a/.claude/skills/iikit-core/scripts/bash/verify-assertion-integrity.sh
+++ b/.claude/skills/iikit-core/scripts/bash/verify-assertion-integrity.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+# verify-assertion-integrity.sh — CI-callable assertion integrity verification
+#
+# Verifies that .feature file assertion hashes match stored hashes in context.json.
+# Designed to run in any CI system (GitHub Actions, GitLab CI, Jenkins, etc.)
+# as a server-side enforcement layer that cannot be bypassed by --no-verify.
+#
+# Usage:
+#   ./verify-assertion-integrity.sh [--json] [--project-root PATH]
+#
+# Exit codes:
+#   0 — All assertions verified (or no assertions found)
+#   1 — Assertion integrity check failed (hash mismatch)
+#   2 — Missing dependencies (jq, shasum)
+#
+# Requires: bash 3.2+, jq, shasum
+
+set -euo pipefail
+
+# Source shared functions by calling testify-tdd.sh compute-hash to verify it works,
+# then define the functions we need by extracting them from the script.
+SCRIPT_DIR="$(CDPATH="" cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# extract_assertions and compute_assertion_hash are defined in testify-tdd.sh.
+# We source the function definitions by evaluating only the function blocks.
+eval "$(sed -n '/^extract_assertions()/,/^}/p' "$SCRIPT_DIR/testify-tdd.sh")"
+eval "$(sed -n '/^compute_assertion_hash()/,/^}/p' "$SCRIPT_DIR/testify-tdd.sh")"
+
+# =============================================================================
+# ARGUMENT PARSING
+# =============================================================================
+
+JSON_MODE=false
+PROJECT_ROOT=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --json) JSON_MODE=true; shift ;;
+        --project-root) PROJECT_ROOT="$2"; shift 2 ;;
+        --help|-h)
+            cat <<'EOF'
+Usage: verify-assertion-integrity.sh [--json] [--project-root PATH]
+
+Verifies .feature file assertion hashes against stored hashes in context.json.
+Server-side enforcement that cannot be bypassed by --no-verify.
+
+Options:
+  --json              Output results in JSON format
+  --project-root PATH Override project root directory
+  --help, -h          Show this help message
+
+Exit codes:
+  0 — All assertions verified (or no assertions found)
+  1 — Assertion integrity check failed
+  2 — Missing dependencies
+EOF
+            exit 0
+            ;;
+        *) echo "ERROR: Unknown option '$1'" >&2; exit 2 ;;
+    esac
+done
+
+# =============================================================================
+# DEPENDENCY CHECK
+# =============================================================================
+
+for cmd in jq shasum; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+        echo "ERROR: Required command '$cmd' not found" >&2
+        exit 2
+    fi
+done
+
+# =============================================================================
+# PROJECT ROOT DETECTION
+# =============================================================================
+
+if [[ -z "$PROJECT_ROOT" ]]; then
+    if git rev-parse --show-toplevel >/dev/null 2>&1; then
+        PROJECT_ROOT=$(git rev-parse --show-toplevel)
+    else
+        PROJECT_ROOT="$(pwd)"
+    fi
+fi
+
+SPECS_DIR="$PROJECT_ROOT/specs"
+
+if [[ ! -d "$SPECS_DIR" ]]; then
+    if $JSON_MODE; then
+        printf '{"status":"pass","features_checked":0,"message":"No specs/ directory found"}\n'
+    fi
+    exit 0
+fi
+
+# =============================================================================
+# VERIFY ALL FEATURES
+# =============================================================================
+
+TOTAL_CHECKED=0
+TOTAL_PASSED=0
+TOTAL_FAILED=0
+TOTAL_SKIPPED=0
+FAILURES=()
+
+for feat_dir in "$SPECS_DIR"/*/; do
+    [[ ! -d "$feat_dir" ]] && continue
+    feat_name=$(basename "$feat_dir")
+
+    FEATURES_DIR="$feat_dir/tests/features"
+    CONTEXT_FILE="$feat_dir/context.json"
+
+    # Skip features without .feature files
+    if [[ ! -d "$FEATURES_DIR" ]]; then
+        continue
+    fi
+
+    FEATURE_COUNT=$(find "$FEATURES_DIR" -maxdepth 1 -name "*.feature" -type f 2>/dev/null | wc -l | tr -d ' ')
+    if [[ "$FEATURE_COUNT" -eq 0 ]]; then
+        continue
+    fi
+
+    TOTAL_CHECKED=$((TOTAL_CHECKED + 1))
+
+    # Compute current hash from .feature files on disk
+    CURRENT_HASH=$(compute_assertion_hash "$FEATURES_DIR")
+
+    if [[ "$CURRENT_HASH" == "NO_ASSERTIONS" ]]; then
+        TOTAL_SKIPPED=$((TOTAL_SKIPPED + 1))
+        continue
+    fi
+
+    # Read stored hash from context.json
+    if [[ ! -f "$CONTEXT_FILE" ]]; then
+        TOTAL_SKIPPED=$((TOTAL_SKIPPED + 1))
+        continue
+    fi
+
+    CONTEXT_JSON=$(cat "$CONTEXT_FILE" 2>/dev/null)
+    if ! echo "$CONTEXT_JSON" | jq empty 2>/dev/null; then
+        TOTAL_SKIPPED=$((TOTAL_SKIPPED + 1))
+        continue
+    fi
+
+    STORED_HASH=$(echo "$CONTEXT_JSON" | jq -r '.testify.assertion_hash // ""' 2>/dev/null || echo "")
+    STORED_DIR=$(echo "$CONTEXT_JSON" | jq -r '.testify.features_dir // ""' 2>/dev/null || echo "")
+
+    if [[ -z "$STORED_HASH" ]] || [[ -z "$STORED_DIR" ]]; then
+        TOTAL_SKIPPED=$((TOTAL_SKIPPED + 1))
+        continue
+    fi
+
+    # Compare hashes
+    if [[ "$STORED_HASH" == "$CURRENT_HASH" ]]; then
+        TOTAL_PASSED=$((TOTAL_PASSED + 1))
+    else
+        TOTAL_FAILED=$((TOTAL_FAILED + 1))
+        FAILURES+=("$feat_name: expected=$STORED_HASH actual=$CURRENT_HASH")
+    fi
+done
+
+# =============================================================================
+# OUTPUT
+# =============================================================================
+
+if $JSON_MODE; then
+    STATUS="pass"
+    [[ "$TOTAL_FAILED" -gt 0 ]] && STATUS="fail"
+
+    FAILURES_JSON="[]"
+    if [[ ${#FAILURES[@]} -gt 0 ]]; then
+        FAILURES_JSON=$(printf '"%s",' "${FAILURES[@]}")
+        FAILURES_JSON="[${FAILURES_JSON%,}]"
+    fi
+
+    printf '{"status":"%s","features_checked":%d,"passed":%d,"failed":%d,"skipped":%d,"failures":%s}\n' \
+        "$STATUS" "$TOTAL_CHECKED" "$TOTAL_PASSED" "$TOTAL_FAILED" "$TOTAL_SKIPPED" "$FAILURES_JSON"
+else
+    if [[ "$TOTAL_CHECKED" -eq 0 ]]; then
+        echo "[iikit] No features with .feature files found — nothing to verify."
+        exit 0
+    fi
+
+    echo "[iikit] Assertion integrity check: $TOTAL_CHECKED features checked"
+    echo "  Passed:  $TOTAL_PASSED"
+    echo "  Failed:  $TOTAL_FAILED"
+    echo "  Skipped: $TOTAL_SKIPPED"
+
+    if [[ "$TOTAL_FAILED" -gt 0 ]]; then
+        echo ""
+        echo "+-------------------------------------------------------------+"
+        echo "|  ASSERTION INTEGRITY CHECK FAILED                           |"
+        echo "+-------------------------------------------------------------+"
+        echo ""
+        for failure in "${FAILURES[@]}"; do
+            echo "  FAILED: $failure"
+        done
+        echo ""
+        echo "  .feature assertions were modified without re-running /iikit-04-testify."
+        echo "  This may indicate a --no-verify bypass of the pre-commit hook."
+        echo ""
+    fi
+fi
+
+if [[ "$TOTAL_FAILED" -gt 0 ]]; then
+    exit 1
+fi
+
+exit 0

--- a/.claude/skills/iikit-core/scripts/bash/verify-assertion-integrity.sh
+++ b/.claude/skills/iikit-core/scripts/bash/verify-assertion-integrity.sh
@@ -20,7 +20,23 @@ set -euo pipefail
 # Extract function definitions from testify-tdd.sh without executing it.
 SCRIPT_DIR="$(CDPATH="" cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 eval "$(sed -n '/^extract_assertions()/,/^}/p' "$SCRIPT_DIR/testify-tdd.sh")"
-eval "$(sed -n '/^compute_assertion_hash()/,/^}/p' "$SCRIPT_DIR/testify-tdd.sh")"
+
+# compute_assertion_hash from testify-tdd.sh uses shasum -a 256.
+# Override to support sha256sum (Linux) when shasum is not available.
+compute_assertion_hash() {
+    local input_path="$1"
+    local assertions
+    assertions=$(extract_assertions "$input_path")
+    if [[ -z "$assertions" ]]; then
+        echo "NO_ASSERTIONS"
+        return
+    fi
+    if command -v shasum >/dev/null 2>&1; then
+        printf '%s' "$assertions" | shasum -a 256 | cut -d' ' -f1
+    else
+        printf '%s' "$assertions" | sha256sum | cut -d' ' -f1
+    fi
+}
 
 # =============================================================================
 # ARGUMENT PARSING
@@ -32,7 +48,11 @@ PROJECT_ROOT=""
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --json) JSON_MODE=true; shift ;;
-        --project-root) PROJECT_ROOT="$2"; shift 2 ;;
+        --project-root)
+            if [[ $# -lt 2 ]] || [[ "$2" == --* ]]; then
+                echo "ERROR: --project-root requires a path argument" >&2; exit 2
+            fi
+            PROJECT_ROOT="$2"; shift 2 ;;
         --help|-h)
             cat <<'EOF'
 Usage: verify-assertion-integrity.sh [--json] [--project-root PATH]

--- a/.claude/skills/iikit-core/templates/constitution-template.md
+++ b/.claude/skills/iikit-core/templates/constitution-template.md
@@ -40,6 +40,20 @@
 [SECTION_3_CONTENT]
 <!-- Example: Code review requirements, testing gates, deployment approval process, etc. -->
 
+## Integrity
+
+### Pre-Commit Hook Enforcement (NON-NEGOTIABLE)
+
+Pre-commit hooks are a critical integrity gate. The following are prohibited:
+
+- **NEVER** use `git commit --no-verify` or `git commit -n` to bypass hooks
+- **NEVER** delete, modify, or disable files in `.git/hooks/`
+- **NEVER** use git plumbing commands (`git commit-tree`, `git mktree`) to circumvent hooks
+- If a pre-commit hook blocks your commit, **fix the root cause** — do not work around the hook
+- For assertion integrity failures: re-run `/iikit-04-testify` to regenerate hashes
+
+**CI enforcement recommended**: Add `verify-assertion-integrity.sh` to your CI pipeline for server-side verification that cannot be bypassed. See the CI integration reference for setup instructions.
+
 ## Governance
 <!-- Example: Constitution supersedes all other practices; Amendments require documentation, approval, migration plan -->
 

--- a/tiles/intent-integrity-kit/rules/assertion-integrity.md
+++ b/tiles/intent-integrity-kit/rules/assertion-integrity.md
@@ -8,3 +8,6 @@ alwaysApply: true
 - NEVER modify test assertions to make failing tests pass — fix the production code instead
 - NEVER delete or overwrite `context.json` assertion hashes — they are the integrity anchor
 - If a pre-commit hook blocks your commit for hash mismatch, do NOT use `--no-verify` — re-run `/iikit-04-testify`
+- NEVER use `git commit --no-verify`, `git commit -n`, or any mechanism to bypass pre-commit hooks
+- NEVER delete, modify, or disable `.git/hooks/pre-commit`
+- NEVER use git plumbing commands (`git commit-tree`, `git mktree`) to circumvent hook enforcement


### PR DESCRIPTION
## Summary
- **CI verification script** (`verify-assertion-integrity.sh`): Server-side hash verification that works in any CI system. Scans all features, computes assertion hashes, compares against stored hashes. Exit 1 on mismatch.
- **PreToolUse hook** (`check-hook-bypass.sh`): Claude Code hook that blocks hook bypass attempts (flag bypass, hook file deletion, git plumbing). Agent-specific speed bump.
- **Constitution template**: New "Pre-Commit Hook Enforcement (NON-NEGOTIABLE)" section prohibiting all bypass mechanisms.
- **Assertion integrity rules**: Strengthened with explicit bypass prohibitions.
- **Pre-commit hook output**: Removed "To bypass" hints that teach agents the bypass path.
- **CI reference doc**: Setup examples for GitHub Actions, GitLab CI, and generic CI.

## Defense layers
1. **Pre-commit hook** (existing) — catches unintentional tampering
2. **Agent rules** (assertion-integrity.md) — instruction-level prohibition
3. **Constitution template** — project-level governance
4. **PreToolUse hook** — Claude Code enforcement (agent-specific)
5. **CI verification script** — server-side, cannot be bypassed

## Test plan
- [ ] `verify-assertion-integrity.sh` exits 0 with no features
- [ ] `verify-assertion-integrity.sh` exits 0 with valid hashes
- [ ] `verify-assertion-integrity.sh` exits 1 with tampered assertions
- [ ] `verify-assertion-integrity.sh --json` outputs valid JSON
- [ ] PreToolUse hook blocks `git commit` with bypass flag
- [ ] PreToolUse hook allows normal `git commit -m "msg"`
- [ ] Constitution template includes integrity section
- [ ] Pre-commit hook no longer suggests bypass command

🤖 Generated with [Claude Code](https://claude.com/claude-code)