### PR TITLE
chore: update changelog and bump to v2.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v2.10.0
 
 ### Bug Fixes
-- **Dashboard replace corruption** (#49): `String.prototype.replace()` in `generate-dashboard.js` now uses function callbacks to prevent `$`-pattern corruption (`$'`, `` $` ``, `$$`, `$&`) in spec/task content.
+- **Dashboard replace corruption** (#49): `String.prototype.replace()` in `generate-dashboard.js` now uses function callbacks to prevent `$`-pattern corruption (`$'`, ``$```, `$$`, `$&`) in spec/task content.
 - **Branch detection cascade** (#44, #45): `get_current_branch()` now prioritizes the git branch over the stale `.specify/active-feature` file when on a feature branch (`NNN-*`). Fixes wrong feature detection after switching branches.
 - **Pre-commit step definitions gate** (#48): Gate 1 now checks both working tree and git staging area (`--diff-filter=ACMR`) for step definition files, preventing false warnings during `/iikit-07-implement`.
 - **Dashboard clarification panels** (#39): Clarification badges are now clickable — `pointer-events: auto` with `addEventListener` navigates to the clarify view panel. Added `aria-label` for accessibility.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## v2.10.0
+
+### Bug Fixes
+- **Dashboard replace corruption** (#49): `String.prototype.replace()` in `generate-dashboard.js` now uses function callbacks to prevent `$`-pattern corruption (`$'`, `` $` ``, `$$`, `$&`) in spec/task content.
+- **Branch detection cascade** (#44, #45): `get_current_branch()` now prioritizes the git branch over the stale `.specify/active-feature` file when on a feature branch (`NNN-*`). Fixes wrong feature detection after switching branches.
+- **Pre-commit step definitions gate** (#48): Gate 1 now checks both working tree and git staging area (`--diff-filter=ACMR`) for step definition files, preventing false warnings during `/iikit-07-implement`.
+- **Dashboard clarification panels** (#39): Clarification badges are now clickable — `pointer-events: auto` with `addEventListener` navigates to the clarify view panel. Added `aria-label` for accessibility.
+
+### Features
+- **GitHub Copilot support** (#40): Added `.github/copilot-instructions.md` symlink to `AGENTS.md`, updated setup scripts (Unix + Windows) with cross-directory symlink support, added `copilot` case to `update-agent-context`.
+- **Assertion integrity enforcement** (#55): Defense-in-depth against pre-commit hook bypass:
+  - `verify-assertion-integrity.sh` — CI-callable server-side hash verification (agent-agnostic, works in any CI)
+  - `check-hook-bypass.sh` — Claude Code PreToolUse hook blocking `--no-verify`, hook deletion, and git plumbing bypass
+  - Constitution template — new "Pre-Commit Hook Enforcement (NON-NEGOTIABLE)" section
+  - Assertion integrity rules — explicit bypass prohibitions added
+  - Pre-commit hook output no longer suggests `--no-verify` as bypass path
+
+### Closed Without Code Change
+- **#38**: Dashboard health score parser/analyze mismatch — already fixed in current code.
+- **#43**: `--version` exit code null — Tessl CLI bug, not IIKit.
+
 ## v2.9.0
 
 - **Commit strategy choice**: `/iikit-07-implement` asks users to choose between per-task commits (bisectable history, default) or batch commits (per-phase, ~47% faster). Batch mode cuts implementation from ~58 turns to ~31 turns.

--- a/tiles/intent-integrity-kit/README.md
+++ b/tiles/intent-integrity-kit/README.md
@@ -6,21 +6,23 @@
 
 An AI coding assistant toolkit that preserves your intent from idea to implementation, with cryptographic verification at each step. Compatible with Claude Code, OpenAI Codex, Google Gemini, OpenCode, and GitHub Copilot.
 
-## What's New in v2.9.0
+## What's New in v2.10.0
 
-- **Implementation commit strategy choice**: `/iikit-07-implement` now asks upfront — per-task commits (clean bisectable history) or batch commits (per-phase, ~47% faster). Batch mode cuts implementation turns in half by eliminating per-task git round-trips.
-- **Unified post-phase.sh**: Commit + dashboard refresh + next-step computation consolidated into a single script call. Reduces 3 tool call round-trips to 1 per phase, saving ~26% on implementation time.
-- **Dashboard deduplication**: Removed redundant dashboard generation from `check-prerequisites.sh` — was generating the dashboard twice per phase (once in prerequisites, once after artifact creation).
+- **Assertion integrity enforcement**: Defense-in-depth against pre-commit hook bypass — CI verification script (`verify-assertion-integrity.sh`) for server-side enforcement, PreToolUse hook for Claude Code, constitution template with hook enforcement section.
+- **GitHub Copilot support**: Fifth agent — `.github/copilot-instructions.md` symlink, cross-directory setup scripts, `update-agent-context copilot` support.
+- **Bug fixes**: Dashboard `$`-pattern corruption (#49), branch detection cascade (#44/#45), pre-commit step definitions gate (#48), clarification panel navigation (#39).
+
+### v2.9
+
+Implementation commit strategy choice (per-task vs batch), unified post-phase.sh (3 tool calls → 1), dashboard deduplication.
 
 ### v2.8
 
-- **14 eval scenarios**: 9 new cross-phase and full-pipeline evals testing intent preservation across phase boundaries, plus 3 auto-generated and 2 reworked existing evals. Baseline 48% → with context 88%.
-- **Skill compliance fixes**: Constitution creates `.specify/context.json` with TDD determination in the same write step (was separate step, consistently skipped). Plan skill spec quality gate marked MANDATORY on every run including re-runs. Bugfix skill reads TDD from context.json with fallback when scripts unavailable.
-- **Eval anti-bleeding**: All task.md files stripped of narrator coaching that telegraphed criteria to the agent. Scenarios now test genuine skill behavior, not instruction following.
+14 eval scenarios (baseline 48% → 88%), skill compliance fixes, eval anti-bleeding.
 
 ### v2.7
 
-Dashboard overhaul (premise cards, architecture parser, tile review scores, bug cross-links), 27 bug fixes from E2E testing across 12 projects, externalized next-step state machine, generic clarify utility, Bash 3.2 macOS compatibility.
+Dashboard overhaul, 27 bug fixes from E2E testing across 12 projects, externalized next-step state machine, generic clarify utility, Bash 3.2 macOS compatibility.
 
 [Full changelog →](https://github.com/intent-integrity-chain/kit/blob/main/CHANGELOG.md)
 

--- a/tiles/intent-integrity-kit/README.md
+++ b/tiles/intent-integrity-kit/README.md
@@ -10,7 +10,7 @@ An AI coding assistant toolkit that preserves your intent from idea to implement
 
 - **Assertion integrity enforcement**: Defense-in-depth against pre-commit hook bypass — CI verification script (`verify-assertion-integrity.sh`) for server-side enforcement, PreToolUse hook for Claude Code, constitution template with hook enforcement section.
 - **GitHub Copilot support**: Fifth agent — `.github/copilot-instructions.md` symlink, cross-directory setup scripts, `update-agent-context copilot` support.
-- **Bug fixes**: Dashboard `$`-pattern corruption (#49), branch detection cascade (#44/#45), pre-commit step definitions gate (#48), clarification panel navigation (#39).
+- **4 bug fixes**: Dashboard `$`-pattern corruption (#49), branch detection cascade (#44/#45), pre-commit step definitions gate (#48), clarification panel navigation (#39).
 
 ### v2.9
 

--- a/tiles/intent-integrity-kit/tile.json
+++ b/tiles/intent-integrity-kit/tile.json
@@ -2,7 +2,7 @@
   "name": "tessl-labs/intent-integrity-kit",
   "version": "2.10.0",
   "summary": "Closing the intent-to-code chasm - specification-driven development with BDD verification chain",
-  "description": "Intent Integrity Kit (IIKit) preserves your intent from idea to implementation through specification-driven development with BDD verification chain. Compatible with Claude Code, Codex, Gemini, OpenCode, and GitHub Copilot.\n\nWhat's new in v2.10.0: Assertion integrity enforcement (CI verification script, PreToolUse hook, constitution template). GitHub Copilot support (fifth agent). 6 bug fixes: dashboard corruption, branch detection, pre-commit gate, clarification panels.",
+  "description": "Intent Integrity Kit (IIKit) preserves your intent from idea to implementation through specification-driven development with BDD verification chain. Compatible with Claude Code, Codex, Gemini, OpenCode, and GitHub Copilot.\n\nWhat's new in v2.10.0: Assertion integrity enforcement (CI verification script, PreToolUse hook, constitution template). GitHub Copilot support (fifth agent). 4 bug fixes: dashboard corruption, branch detection, pre-commit gate, clarification panels.",
   "entrypoint": "README.md",
   "private": false,
   "repository": "https://github.com/intent-integrity-chain/kit",

--- a/tiles/intent-integrity-kit/tile.json
+++ b/tiles/intent-integrity-kit/tile.json
@@ -1,8 +1,8 @@
 {
   "name": "tessl-labs/intent-integrity-kit",
-  "version": "2.9.12",
+  "version": "2.10.0",
   "summary": "Closing the intent-to-code chasm - specification-driven development with BDD verification chain",
-  "description": "Intent Integrity Kit (IIKit) preserves your intent from idea to implementation through specification-driven development with BDD verification chain. Compatible with Claude Code, Codex, Gemini, OpenCode, and GitHub Copilot.\n\nWhat's new in v2.9.0: Implementation commit strategy choice (per-task or batch) — batch commits cut implementation time by ~47%. Unified post-phase.sh reduces 3 tool calls to 1 per phase (commit + dashboard + next-step), saving ~26% on per-task runs. Removed redundant dashboard generation from check-prerequisites.sh.",
+  "description": "Intent Integrity Kit (IIKit) preserves your intent from idea to implementation through specification-driven development with BDD verification chain. Compatible with Claude Code, Codex, Gemini, OpenCode, and GitHub Copilot.\n\nWhat's new in v2.10.0: Assertion integrity enforcement (CI verification script, PreToolUse hook, constitution template). GitHub Copilot support (fifth agent). 6 bug fixes: dashboard corruption, branch detection, pre-commit gate, clarification panels.",
   "entrypoint": "README.md",
   "private": false,
   "repository": "https://github.com/intent-integrity-chain/kit",


### PR DESCRIPTION
## Summary
- Add v2.10.0 section to CHANGELOG.md covering all 6 PRs merged today
- Update "What's New" in tile README (features first, bug fixes second)
- Bump tile.json version from 2.9.12 to 2.10.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)