### PR TITLE
docs(readme,iikit-core): recommend caveman companion tile

### DIFF
--- a/.claude/skills/iikit-core/SKILL.md
+++ b/.claude/skills/iikit-core/SKILL.md
@@ -92,7 +92,7 @@ If validation fails (remaining placeholders or missing sections), fix and re-val
 
 #### Step 5 — Report
 
-Directories created, hook status, PREMISE.md status. Suggest `/iikit-00-constitution`. Recommend installing companion `juliusbrussee/caveman` (`tessl i juliusbrussee/caveman`) and activating `/caveman full` at session start — ~30% cost and wall-clock savings measured across the IIKit workflow.
+Directories created, hook status, PREMISE.md status. Suggest `/iikit-00-constitution`. Recommend installing companion `juliusbrussee/caveman` (`tessl install juliusbrussee/caveman`) and activating `/caveman full` at session start — ~30% cost and wall-clock savings measured across the IIKit workflow.
 
 #### Step 6 — Seed backlog from PRD (optional)
 

--- a/.claude/skills/iikit-core/SKILL.md
+++ b/.claude/skills/iikit-core/SKILL.md
@@ -92,7 +92,7 @@ If validation fails (remaining placeholders or missing sections), fix and re-val
 
 #### Step 5 — Report
 
-Directories created, hook status, PREMISE.md status. Suggest `/iikit-00-constitution`.
+Directories created, hook status, PREMISE.md status. Suggest `/iikit-00-constitution`. Recommend installing companion `juliusbrussee/caveman` (`tessl i juliusbrussee/caveman`) and activating `/caveman full` at session start — ~30% cost and wall-clock savings measured across the IIKit workflow.
 
 #### Step 6 — Seed backlog from PRD (optional)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Documentation
+- **Caveman companion recommendation** (#46): README "Recommended Companion" section and `/iikit-core init` Step 5 now point users to [`juliusbrussee/caveman`](https://tessl.io/registry/juliusbrussee/caveman). A 4-demo × 2-arm benchmark measured ~30% cost and wall-clock reduction across the full IIKit workflow with FR coverage preserved. Issue #46 remains open for deeper input-compression work on IIKit's own SKILL.md files.
+
 ## v2.10.0
 
 ### Bug Fixes

--- a/tiles/intent-integrity-kit/README.md
+++ b/tiles/intent-integrity-kit/README.md
@@ -56,6 +56,22 @@ tessl install tessl-labs/intent-integrity-kit
 
 > **Note**: `tessl install` is the only supported installation method. During publish, shared reference and template files are copied into each skill for self-containment. Cloning the repo directly does not produce self-contained skills.
 
+### Recommended Companion: Caveman
+
+Install [`juliusbrussee/caveman`](https://tessl.io/registry/juliusbrussee/caveman) alongside IIKit for terser agent output. A 4-demo × 2-arm benchmark measured **~30% cost reduction and ~30% faster wall-clock** across the full IIKit workflow (spec → clarify → plan → testify → tasks → analyze → implement), with FR coverage preserved in every run.
+
+```bash
+tessl install juliusbrussee/caveman
+```
+
+Then, at the start of each IIKit session:
+
+```
+/caveman full
+```
+
+Caveman compresses agent chat between tool calls; your spec, plan, and task artifacts stay in normal prose. See [tracking issue #46](https://github.com/intent-integrity-chain/kit/issues/46) for the benchmark write-up and discussion of deeper input-compression work.
+
 ### Your First Project
 
 ```bash


### PR DESCRIPTION
**Author-Model:** claude-opus-4-7

## Summary

- README gets a "Recommended Companion: Caveman" section right after Installation, pointing users to [`juliusbrussee/caveman`](https://tessl.io/registry/juliusbrussee/caveman) with the benchmark headline (~30% cost, ~30% wall-clock) and `/caveman full` activation instruction.
- `/iikit-core init` Step 5 (Report) adds a one-line nudge with the same recommendation so users see it at project bootstrap.
- CHANGELOG "Unreleased" entry tracks the scope and links to #46.
- No hooks, no custom `/iikit-caveman` skill, no AGENTS.md changes — caveman has built-in trigger phrases + Auto-Clarity that cover IIKit's needs. Issue #46 stays open for the publish-pipeline input-compression work on IIKit's own SKILL.md files.

Based on a 4-demo × 2-arm benchmark (todo CLI / URL-shortener API / Rust semver lib / CSV pipeline) measuring full IIKit workflows with and without caveman active. All 8 runs completed successfully with green test suites. See comment on #46 for full results.

## Test plan

- [ ] `README.md` renders correctly on GitHub (symlink target `tiles/intent-integrity-kit/README.md` reachable)
- [ ] `.claude/skills/iikit-core/SKILL.md` Step 5 still parses as a valid IIKit skill step — no broken Markdown
- [ ] `tiles/intent-integrity-kit/skills/iikit-core/SKILL.md` picks up the edit via the `tiles/intent-integrity-kit/skills -> ../../.claude/skills` symlink
- [ ] CI bats + jest + playwright suites pass on the PR (docs change; no logic touched)
- [ ] Skill review (if wired into this repo's CI) still scores ≥85 for `iikit-core`

🤖 Generated with [Claude Code](https://claude.com/claude-code)