### PR TITLE
fix(scripts): follow symlinks when scanning tests/features for .feature files

### DIFF
--- a/.claude/skills/iikit-core/scripts/bash/bugfix-helpers.sh
+++ b/.claude/skills/iikit-core/scripts/bash/bugfix-helpers.sh
@@ -112,7 +112,7 @@ cmd_validate_feature() {
     [[ -f "$feature_dir/bugs.md" ]] && has_bugs="true"
     if [[ -d "$feature_dir/tests/features" ]]; then
         local fcount
-        fcount=$(find "$feature_dir/tests/features" -maxdepth 1 -name "*.feature" -type f 2>/dev/null | wc -l | tr -d ' ')
+        fcount=$(find -L "$feature_dir/tests/features" -maxdepth 1 -name "*.feature" -type f 2>/dev/null | wc -l | tr -d ' ')
         [[ "$fcount" -gt 0 ]] && has_tests="true"
     fi
 

--- a/.claude/skills/iikit-core/scripts/bash/check-prerequisites.sh
+++ b/.claude/skills/iikit-core/scripts/bash/check-prerequisites.sh
@@ -655,7 +655,7 @@ if [[ "$PHASE" == "05" || "$PHASE" == "06" || "$PHASE" == "07" || "$PHASE" == "0
     if [[ "$TDD_DET" == "mandatory" ]]; then
         HAS_FEATURES=false
         if [[ -d "$FEATURE_DIR/tests/features" ]]; then
-            FCOUNT=$(find "$FEATURE_DIR/tests/features" -maxdepth 1 -name "*.feature" -type f 2>/dev/null | wc -l | tr -d ' ')
+            FCOUNT=$(find -L "$FEATURE_DIR/tests/features" -maxdepth 1 -name "*.feature" -type f 2>/dev/null | wc -l | tr -d ' ')
             [[ "$FCOUNT" -gt 0 ]] && HAS_FEATURES=true
         fi
 

--- a/.claude/skills/iikit-core/scripts/bash/pre-commit-hook.sh
+++ b/.claude/skills/iikit-core/scripts/bash/pre-commit-hook.sh
@@ -74,7 +74,7 @@ if [[ "$TDD_DETERMINATION" == "mandatory" ]] && [[ -n "$STAGED_CODE_FILES" ]]; t
     for feat_dir in "$REPO_ROOT"/specs/[0-9][0-9][0-9]-*/; do
         [[ ! -d "$feat_dir" ]] && continue
         if [[ -d "$feat_dir/tests/features" ]]; then
-            FCOUNT=$(find "$feat_dir/tests/features" -maxdepth 1 -name "*.feature" -type f 2>/dev/null | wc -l | tr -d ' ')
+            FCOUNT=$(find -L "$feat_dir/tests/features" -maxdepth 1 -name "*.feature" -type f 2>/dev/null | wc -l | tr -d ' ')
             [[ "$FCOUNT" -gt 0 ]] && ANY_FEATURES=true && break
         fi
         # Also check legacy test-specs.md
@@ -107,7 +107,7 @@ if [[ -n "$STAGED_CODE_FILES" ]]; then
         [[ ! -d "$FEATURES_DIR" ]] && continue
 
         # Check that at least one .feature file exists
-        FEATURE_COUNT=$(find "$FEATURES_DIR" -maxdepth 1 -name "*.feature" -type f 2>/dev/null | wc -l | tr -d ' ')
+        FEATURE_COUNT=$(find -L "$FEATURES_DIR" -maxdepth 1 -name "*.feature" -type f 2>/dev/null | wc -l | tr -d ' ')
         [[ "$FEATURE_COUNT" -eq 0 ]] && continue
 
         FEAT_NAME=$(basename "$feat_dir")

--- a/.claude/skills/iikit-core/scripts/bash/verify-assertion-integrity.sh
+++ b/.claude/skills/iikit-core/scripts/bash/verify-assertion-integrity.sh
@@ -158,7 +158,7 @@ for feat_dir in "$SPECS_DIR"/*/; do
         continue
     fi
 
-    FEATURE_COUNT=$(find "$FEATURES_DIR" -maxdepth 1 -name "*.feature" -type f 2>/dev/null | wc -l | tr -d ' ')
+    FEATURE_COUNT=$(find -L "$FEATURES_DIR" -maxdepth 1 -name "*.feature" -type f 2>/dev/null | wc -l | tr -d ' ')
     if [[ "$FEATURE_COUNT" -eq 0 ]]; then
         continue
     fi

--- a/.claude/skills/iikit-core/scripts/bash/verify-steps.sh
+++ b/.claude/skills/iikit-core/scripts/bash/verify-steps.sh
@@ -289,7 +289,7 @@ if [[ ! -d "$FEATURES_DIR" ]]; then
 fi
 
 # Check for .feature files
-feature_count=$(find "$FEATURES_DIR" -maxdepth 1 -name "*.feature" -type f 2>/dev/null | wc -l | tr -d ' ')
+feature_count=$(find -L "$FEATURES_DIR" -maxdepth 1 -name "*.feature" -type f 2>/dev/null | wc -l | tr -d ' ')
 if [[ "$feature_count" -eq 0 ]]; then
     if [[ "$JSON_MODE" == "true" ]]; then
         printf '{"status":"DEGRADED","framework":null,"message":"No .feature files found in %s","total_steps":0,"matched_steps":0,"undefined_steps":0,"pending_steps":0,"details":[]}' "$FEATURES_DIR"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Bug Fixes
+- **Symlinked `tests/features/` not traversed by `find`** (#59): Every `find` over `.feature` files in `iikit-core` scripts (`check-prerequisites.sh`, `pre-commit-hook.sh`, `bugfix-helpers.sh`, `verify-assertion-integrity.sh`, `verify-steps.sh`) now passes `-L` so a symlinked `tests/features/` directory (e.g., Maven layout where it points to `src/test/resources/features/`) is followed. Previously the testify gate falsely reported `"features": false` and blocked phases 05–08 even when `.feature` files existed.
+
 ### Documentation
 - **Caveman companion recommendation** (#46): README "Recommended Companion" section and `/iikit-core init` Step 5 now point users to [`juliusbrussee/caveman`](https://tessl.io/registry/juliusbrussee/caveman). A 4-demo × 2-arm benchmark measured ~30% cost and wall-clock reduction across the full IIKit workflow with FR coverage preserved. Issue #46 remains open for deeper input-compression work on IIKit's own SKILL.md files.
 

--- a/tests/bash/check-prerequisites.bats
+++ b/tests/bash/check-prerequisites.bats
@@ -818,3 +818,19 @@ TEMPLATE
     # Both scripts should use the same terminology for "no feature"
     [[ "$cp_stage" == "$ns_stage" ]]
 }
+
+@test "ISSUE-59: --phase 05 passes when tests/features is a symlink to a real directory" {
+    create_mock_feature "001-test-feature"
+
+    # Replace tests/features dir with a symlink to a canonical location
+    # (mirrors Maven layout: specs/NNN/tests/features -> src/test/resources/features)
+    feature_dir="$TEST_DIR/specs/001-test-feature"
+    canonical="$TEST_DIR/src/test/resources/features"
+    mkdir -p "$canonical"
+    mv "$feature_dir/tests/features/test.feature" "$canonical/test.feature"
+    rm -rf "$feature_dir/tests/features"
+    ln -s "$canonical" "$feature_dir/tests/features"
+
+    run "$CHECK_SCRIPT" --phase 05 --json
+    [[ "$status" -eq 0 ]]
+}


### PR DESCRIPTION
**Author-Model:** claude-opus-4-7

## Summary
- `find` without `-L` silently returns zero results when `tests/features/` is a symlink (e.g., Maven layout pointing at `src/test/resources/features/`), causing the testify gate to falsely report features as missing and block phases 05–08
- All five `iikit-core` bash scripts that count `.feature` files now pass `-L`: `check-prerequisites.sh`, `pre-commit-hook.sh`, `bugfix-helpers.sh`, `verify-assertion-integrity.sh`, `verify-steps.sh`
- Added a regression bats test (`ISSUE-59`) that creates a symlinked `tests/features/` and asserts the testify gate passes

## Test plan
- [ ] CI bats suite passes (existing tests + new `ISSUE-59`)
- [ ] CI Pester suite passes (PowerShell scripts unaffected — Windows symlink semantics differ)
- [ ] E2E nightly publish/install verification still green

Closes #59