### PR TITLE
feat(iikit-core): add uninit subcommand for clean tessl uninstall

### DIFF
--- a/.claude/skills/iikit-core/SKILL.md
+++ b/.claude/skills/iikit-core/SKILL.md
@@ -25,7 +25,8 @@ Parse the user input to determine which subcommand to execute.
 1. **init** - Initialize intent-integrity-kit in a new or existing project
 2. **status** - Show current project and feature status
 3. **use** - Select the active feature for multi-feature projects
-4. **help** - Display workflow phases and command reference
+4. **uninit** - Remove iikit scaffolding before `tessl uninstall`
+5. **help** - Display workflow phases and command reference
 
 If no subcommand is provided, show help.
 
@@ -138,6 +139,38 @@ The `$ARGUMENTS` after `use` is the feature selector: a number (`1`, `001`), par
 2. **Report** active feature, stage, and suggest next command: `specified` → `/iikit-clarify` or `/iikit-02-plan` | `planned` → `/iikit-03-checklist` or `/iikit-05-tasks` | `testified` → `/iikit-05-tasks` | `tasks-ready` → `/iikit-07-implement` | `implementing-NN%` → `/iikit-07-implement` (resume) | `complete` → done. Suggest `/clear` before next skill when appropriate.
 
 If no selector, no match, or ambiguous match: show available features with stages and ask user to pick.
+
+## Subcommand: uninit
+
+Remove iikit-managed scaffolding from the project so `tessl uninstall tessl-labs/intent-integrity-kit` does not leave broken hooks or orphaned tile artifacts behind. Run this BEFORE `tessl uninstall` — once the tile is gone, the skill (and this script) are no longer reachable.
+
+### Execution Flow
+
+#### Step 1 — Preview what would be removed
+
+```bash
+bash .tessl/tiles/tessl-labs/intent-integrity-kit/skills/iikit-core/scripts/bash/uninit.sh --dry-run --json
+# Windows: pwsh .tessl/tiles/tessl-labs/intent-integrity-kit/skills/iikit-core/scripts/powershell/uninit.ps1 -DryRun -Json
+```
+
+Parse JSON for `removed` (tile-managed scaffolding the script will delete or strip — `.git/hooks/pre-commit`/`post-commit` IIKit blocks, `.specify/`, `TECH.md` when it carries an iikit phase reference) and `user_content` (paths the caller decides on — `CONSTITUTION.md`, `PREMISE.md`, `specs/`).
+
+#### Step 2 — Confirm with the user
+
+Present the `removed` and `user_content` lists. Ask whether to also delete the user-authored content. Default is to keep it — these files often outlive the tile (constitutions and feature specs encode real project decisions).
+
+#### Step 3 — Run the uninstaller
+
+```bash
+bash .tessl/tiles/tessl-labs/intent-integrity-kit/skills/iikit-core/scripts/bash/uninit.sh --json [--remove-user-content]
+# Windows: pwsh .tessl/tiles/tessl-labs/intent-integrity-kit/skills/iikit-core/scripts/powershell/uninit.ps1 -Json [-RemoveUserContent]
+```
+
+Pass `--remove-user-content` only when the user opted to delete the user-authored files in Step 2.
+
+#### Step 4 — Tell the user the next command
+
+Show the literal `next_step` from the JSON output: `tessl uninstall tessl-labs/intent-integrity-kit`. The script does not invoke `tessl uninstall` itself — that's a separate tool the user runs after this skill finishes.
 
 ## Subcommand: help (also default when no subcommand)
 

--- a/.claude/skills/iikit-core/SKILL.md
+++ b/.claude/skills/iikit-core/SKILL.md
@@ -146,31 +146,22 @@ Remove iikit-managed scaffolding from the project so `tessl uninstall tessl-labs
 
 ### Execution Flow
 
-#### Step 1 — Preview what would be removed
+1. Run the dry-run preview:
+   ```bash
+   bash .tessl/tiles/tessl-labs/intent-integrity-kit/skills/iikit-core/scripts/bash/uninit.sh --dry-run --json
+   # Windows: pwsh .tessl/tiles/tessl-labs/intent-integrity-kit/skills/iikit-core/scripts/powershell/uninit.ps1 -DryRun -Json
+   ```
+   Parse JSON for `removed` (tile-managed scaffolding the script will delete or strip — `.git/hooks/pre-commit`/`post-commit` IIKit blocks, `.specify/`, `TECH.md` when it carries an iikit phase reference) and `user_content` (paths the caller decides on — `CONSTITUTION.md`, `PREMISE.md`, `specs/`).
 
-```bash
-bash .tessl/tiles/tessl-labs/intent-integrity-kit/skills/iikit-core/scripts/bash/uninit.sh --dry-run --json
-# Windows: pwsh .tessl/tiles/tessl-labs/intent-integrity-kit/skills/iikit-core/scripts/powershell/uninit.ps1 -DryRun -Json
-```
+2. **Present results and confirm.** Show the `removed` and `user_content` lists. Ask whether to also delete the user-authored content. Default is to keep it — these files often outlive the tile (constitutions and feature specs encode real project decisions).
 
-Parse JSON for `removed` (tile-managed scaffolding the script will delete or strip — `.git/hooks/pre-commit`/`post-commit` IIKit blocks, `.specify/`, `TECH.md` when it carries an iikit phase reference) and `user_content` (paths the caller decides on — `CONSTITUTION.md`, `PREMISE.md`, `specs/`).
+3. Run the uninstaller. Pass `--remove-user-content` only if the user opted to delete the user-authored files at step 2.
+   ```bash
+   bash .tessl/tiles/tessl-labs/intent-integrity-kit/skills/iikit-core/scripts/bash/uninit.sh --json [--remove-user-content]
+   # Windows: pwsh .tessl/tiles/tessl-labs/intent-integrity-kit/skills/iikit-core/scripts/powershell/uninit.ps1 -Json [-RemoveUserContent]
+   ```
 
-#### Step 2 — Confirm with the user
-
-Present the `removed` and `user_content` lists. Ask whether to also delete the user-authored content. Default is to keep it — these files often outlive the tile (constitutions and feature specs encode real project decisions).
-
-#### Step 3 — Run the uninstaller
-
-```bash
-bash .tessl/tiles/tessl-labs/intent-integrity-kit/skills/iikit-core/scripts/bash/uninit.sh --json [--remove-user-content]
-# Windows: pwsh .tessl/tiles/tessl-labs/intent-integrity-kit/skills/iikit-core/scripts/powershell/uninit.ps1 -Json [-RemoveUserContent]
-```
-
-Pass `--remove-user-content` only when the user opted to delete the user-authored files in Step 2.
-
-#### Step 4 — Tell the user the next command
-
-Show the literal `next_step` from the JSON output: `tessl uninstall tessl-labs/intent-integrity-kit`. The script does not invoke `tessl uninstall` itself — that's a separate tool the user runs after this skill finishes.
+4. **Report next command.** Show the literal `next_step` from the JSON output: `tessl uninstall tessl-labs/intent-integrity-kit`. The script does not invoke `tessl uninstall` itself — that's a separate tool the user runs after this skill finishes.
 
 ## Subcommand: help (also default when no subcommand)
 

--- a/.claude/skills/iikit-core/SKILL.md
+++ b/.claude/skills/iikit-core/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: iikit-core
 description: >-
-  Initialize an IIKit (Intent Integrity Kit) project, check IIKit feature progress, select the active IIKit feature, and display the IIKit workflow command reference.
-  Use when starting a new IIKit project, running IIKit init or setup, checking IIKit status, switching between IIKit features, looking up IIKit available commands and phases, or asking for help with the IIKit workflow.
+  Initialize an IIKit (Intent Integrity Kit) project, uninit (remove IIKit scaffolding before `tessl uninstall`), check IIKit feature progress, select the active IIKit feature, and display the IIKit workflow command reference.
+  Use when starting a new IIKit project, running IIKit init or setup, uninstalling/removing/uninit-ing IIKit before running `tessl uninstall`, checking IIKit status, switching between IIKit features, looking up IIKit available commands and phases, or asking for help with the IIKit workflow.
 license: MIT
 metadata:
   version: "1.6.4"

--- a/.claude/skills/iikit-core/scripts/bash/uninit.sh
+++ b/.claude/skills/iikit-core/scripts/bash/uninit.sh
@@ -60,25 +60,47 @@ HOOKS_DIR="$REPO_ROOT/.git/hooks"
 
 REMOVED=()
 USER_CONTENT=()
+ERRORS=()
 
 # Track an action that would be taken; perform it unless --dry-run.
 record_remove() {
     REMOVED+=("$1")
 }
 
+record_error() {
+    ERRORS+=("$1")
+    printf '[uninit] ERROR: %s\n' "$1" >&2
+}
+
 remove_file() {
     local path="$1"
+    local rel="${path#"$REPO_ROOT/"}"
     if [[ -e "$path" || -L "$path" ]]; then
-        $DRY_RUN || rm -f "$path"
-        record_remove "${path#"$REPO_ROOT/"}"
+        if $DRY_RUN; then
+            record_remove "$rel"
+            return 0
+        fi
+        if rm -f "$path" 2>/dev/null && [[ ! -e "$path" && ! -L "$path" ]]; then
+            record_remove "$rel"
+        else
+            record_error "failed to remove $rel"
+        fi
     fi
 }
 
 remove_dir() {
     local path="$1"
+    local rel="${path#"$REPO_ROOT/"}"
     if [[ -d "$path" ]]; then
-        $DRY_RUN || rm -rf "$path"
-        record_remove "${path#"$REPO_ROOT/"}"
+        if $DRY_RUN; then
+            record_remove "$rel"
+            return 0
+        fi
+        if rm -rf "$path" 2>/dev/null && [[ ! -d "$path" ]]; then
+            record_remove "$rel"
+        else
+            record_error "failed to remove $rel"
+        fi
     fi
 }
 
@@ -171,10 +193,11 @@ join_json_array() {
 NEXT_STEP="tessl uninstall tessl-labs/intent-integrity-kit"
 
 if $JSON_MODE; then
-    printf '{"dry_run":%s,"removed":%s,"user_content":%s,"next_step":"%s"}\n' \
+    printf '{"dry_run":%s,"removed":%s,"user_content":%s,"errors":%s,"next_step":"%s"}\n' \
         "$DRY_RUN" \
         "$(join_json_array "${REMOVED[@]+"${REMOVED[@]}"}")" \
         "$(join_json_array "${USER_CONTENT[@]+"${USER_CONTENT[@]}"}")" \
+        "$(join_json_array "${ERRORS[@]+"${ERRORS[@]}"}")" \
         "$NEXT_STEP"
 else
     if $DRY_RUN; then
@@ -194,3 +217,6 @@ else
     echo ""
     echo "[uninit] Next: $NEXT_STEP"
 fi
+
+# Exit non-zero when any removal failed, so callers see a real failure signal.
+[[ ${#ERRORS[@]} -eq 0 ]] || exit 1

--- a/.claude/skills/iikit-core/scripts/bash/uninit.sh
+++ b/.claude/skills/iikit-core/scripts/bash/uninit.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+# BASH 3.2 REQUIRED — no associative arrays, no mapfile
+#
+# Remove intent-integrity-kit scaffolding from a project so `tessl uninstall`
+# does not leave broken hooks, orphaned `.specify/`, or stale tile artifacts
+# behind. Designed to be run BEFORE `tessl uninstall tessl-labs/intent-integrity-kit`,
+# while the tile is still installed and the skill is reachable.
+#
+# Auto-removes (tile-managed scaffolding):
+#   - .git/hooks/pre-commit  (when marked IIKIT-PRE-COMMIT)
+#   - .git/hooks/post-commit (when marked IIKIT-POST-COMMIT)
+#   - .git/hooks/iikit-pre-commit, iikit-post-commit (alongside installs)
+#   - "IIKit assertion integrity check" chain-call lines from any other hook
+#   - .specify/ directory entirely
+#   - TECH.md (only when it contains an iikit phase reference)
+#
+# Reports as user-authored (caller chooses what to do with these):
+#   - CONSTITUTION.md
+#   - PREMISE.md
+#   - specs/
+#
+# Usage:
+#   uninit.sh [--json] [--dry-run] [--remove-user-content]
+#
+# --dry-run            list what would change without modifying anything
+# --remove-user-content also delete CONSTITUTION.md, PREMISE.md, specs/
+#
+# Output: JSON with `removed` (paths actually deleted/modified),
+#         `user_content` (paths the caller must decide on), and
+#         `next_step` (the literal `tessl uninstall ...` command to run).
+
+set -u
+
+SCRIPT_DIR="$(CDPATH="" cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=common.sh
+source "$SCRIPT_DIR/common.sh"
+
+JSON_MODE=false
+DRY_RUN=false
+REMOVE_USER_CONTENT=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --json) JSON_MODE=true ;;
+        --dry-run) DRY_RUN=true ;;
+        --remove-user-content) REMOVE_USER_CONTENT=true ;;
+        --help|-h)
+            sed -n '2,32p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $arg" >&2
+            exit 1
+            ;;
+    esac
+done
+
+REPO_ROOT="$(get_repo_root)"
+HOOKS_DIR="$REPO_ROOT/.git/hooks"
+
+REMOVED=()
+USER_CONTENT=()
+
+# Track an action that would be taken; perform it unless --dry-run.
+record_remove() {
+    REMOVED+=("$1")
+}
+
+remove_file() {
+    local path="$1"
+    if [[ -e "$path" || -L "$path" ]]; then
+        $DRY_RUN || rm -f "$path"
+        record_remove "${path#"$REPO_ROOT/"}"
+    fi
+}
+
+remove_dir() {
+    local path="$1"
+    if [[ -d "$path" ]]; then
+        $DRY_RUN || rm -rf "$path"
+        record_remove "${path#"$REPO_ROOT/"}"
+    fi
+}
+
+# Strip iikit chain-call lines from a non-iikit hook in place.
+# Looks for the literal "# IIKit assertion integrity check" comment and the
+# immediately-following call line that invokes iikit-pre-commit / iikit-post-commit.
+strip_chain_call() {
+    local hook="$1"
+    local hook_name="$2"
+    [[ -f "$hook" ]] || return 0
+    grep -q "iikit-$hook_name" "$hook" 2>/dev/null || return 0
+
+    if $DRY_RUN; then
+        record_remove "${hook#"$REPO_ROOT/"} (stripped iikit chain-call)"
+        return 0
+    fi
+
+    local tmp
+    tmp="$(mktemp)"
+    awk -v name="iikit-$hook_name" '
+        /^# IIKit assertion integrity check$/ { skip = 2; next }
+        skip > 0 && $0 ~ name { skip--; next }
+        skip > 0 && /^$/      { skip--; next }
+        { print }
+    ' "$hook" > "$tmp"
+    mv "$tmp" "$hook"
+    chmod +x "$hook"
+    record_remove "${hook#"$REPO_ROOT/"} (stripped iikit chain-call)"
+}
+
+# Hook handling: marker-owned hooks deleted outright; otherwise strip chain-call.
+handle_hook() {
+    local hook_name="$1"
+    local marker="$2"
+    local hook="$HOOKS_DIR/$hook_name"
+
+    if [[ -f "$hook" ]] && grep -q "$marker" "$hook" 2>/dev/null; then
+        remove_file "$hook"
+    else
+        strip_chain_call "$hook" "$hook_name"
+    fi
+    remove_file "$HOOKS_DIR/iikit-$hook_name"
+}
+
+if [[ -d "$HOOKS_DIR" ]]; then
+    handle_hook "pre-commit"  "IIKIT-PRE-COMMIT"
+    handle_hook "post-commit" "IIKIT-POST-COMMIT"
+fi
+
+remove_dir "$REPO_ROOT/.specify"
+
+# TECH.md: only remove when it carries an iikit phase reference.
+TECH_MD="$REPO_ROOT/TECH.md"
+if [[ -f "$TECH_MD" ]] && grep -qE '/iikit-[0-9]{2}-' "$TECH_MD" 2>/dev/null; then
+    remove_file "$TECH_MD"
+fi
+
+# User-authored artifacts: report them; caller decides.
+check_user_content() {
+    local path="$1"
+    if [[ -e "$path" ]]; then
+        if $REMOVE_USER_CONTENT; then
+            if [[ -d "$path" ]]; then
+                remove_dir "$path"
+            else
+                remove_file "$path"
+            fi
+        else
+            USER_CONTENT+=("${path#"$REPO_ROOT/"}")
+        fi
+    fi
+}
+
+check_user_content "$REPO_ROOT/CONSTITUTION.md"
+check_user_content "$REPO_ROOT/PREMISE.md"
+check_user_content "$REPO_ROOT/specs"
+
+# Output
+join_json_array() {
+    local first=true
+    printf '['
+    for item in "$@"; do
+        $first || printf ','
+        first=false
+        printf '"%s"' "$(printf '%s' "$item" | sed 's/\\/\\\\/g; s/"/\\"/g')"
+    done
+    printf ']'
+}
+
+NEXT_STEP="tessl uninstall tessl-labs/intent-integrity-kit"
+
+if $JSON_MODE; then
+    printf '{"dry_run":%s,"removed":%s,"user_content":%s,"next_step":"%s"}\n' \
+        "$DRY_RUN" \
+        "$(join_json_array "${REMOVED[@]+"${REMOVED[@]}"}")" \
+        "$(join_json_array "${USER_CONTENT[@]+"${USER_CONTENT[@]}"}")" \
+        "$NEXT_STEP"
+else
+    if $DRY_RUN; then
+        echo "[uninit] DRY RUN — no files changed"
+    fi
+    if [[ ${#REMOVED[@]} -gt 0 ]]; then
+        echo "[uninit] Removed:"
+        for path in "${REMOVED[@]}"; do echo "  - $path"; done
+    else
+        echo "[uninit] No tile-managed scaffolding found."
+    fi
+    if [[ ${#USER_CONTENT[@]} -gt 0 ]]; then
+        echo ""
+        echo "[uninit] User-authored content kept (re-run with --remove-user-content to delete):"
+        for path in "${USER_CONTENT[@]}"; do echo "  - $path"; done
+    fi
+    echo ""
+    echo "[uninit] Next: $NEXT_STEP"
+fi

--- a/.claude/skills/iikit-core/scripts/bash/uninit.sh
+++ b/.claude/skills/iikit-core/scripts/bash/uninit.sh
@@ -110,25 +110,44 @@ remove_dir() {
 strip_chain_call() {
     local hook="$1"
     local hook_name="$2"
+    local rel="${hook#"$REPO_ROOT/"}"
     [[ -f "$hook" ]] || return 0
     grep -q "iikit-$hook_name" "$hook" 2>/dev/null || return 0
 
     if $DRY_RUN; then
-        record_remove "${hook#"$REPO_ROOT/"} (stripped iikit chain-call)"
+        record_remove "$rel (stripped iikit chain-call)"
         return 0
     fi
 
     local tmp
-    tmp="$(mktemp)"
-    awk -v name="iikit-$hook_name" '
+    if ! tmp="$(mktemp 2>/dev/null)"; then
+        record_error "failed to allocate temp file while rewriting $rel"
+        return 1
+    fi
+
+    if ! awk -v name="iikit-$hook_name" '
         /^# IIKit assertion integrity check$/ { skip = 2; next }
         skip > 0 && $0 ~ name { skip--; next }
         skip > 0 && /^$/      { skip--; next }
         { print }
-    ' "$hook" > "$tmp"
-    mv "$tmp" "$hook"
-    chmod +x "$hook"
-    record_remove "${hook#"$REPO_ROOT/"} (stripped iikit chain-call)"
+    ' "$hook" > "$tmp" 2>/dev/null; then
+        rm -f "$tmp"
+        record_error "failed to filter $rel"
+        return 1
+    fi
+
+    if ! mv "$tmp" "$hook" 2>/dev/null; then
+        rm -f "$tmp"
+        record_error "failed to overwrite $rel"
+        return 1
+    fi
+
+    if ! chmod +x "$hook" 2>/dev/null; then
+        record_error "failed to restore exec bit on $rel"
+        return 1
+    fi
+
+    record_remove "$rel (stripped iikit chain-call)"
 }
 
 # Hook handling: marker-owned hooks deleted outright; otherwise strip chain-call.

--- a/.claude/skills/iikit-core/scripts/bash/uninit.sh
+++ b/.claude/skills/iikit-core/scripts/bash/uninit.sh
@@ -83,7 +83,7 @@ remove_file() {
         if rm -f "$path" 2>/dev/null && [[ ! -e "$path" && ! -L "$path" ]]; then
             record_remove "$rel"
         else
-            record_error "failed to remove $rel"
+            record_error "failed to remove $rel — check that you have write permission on the parent directory, then delete '$rel' manually before running \`tessl uninstall\`"
         fi
     fi
 }
@@ -99,7 +99,7 @@ remove_dir() {
         if rm -rf "$path" 2>/dev/null && [[ ! -d "$path" ]]; then
             record_remove "$rel"
         else
-            record_error "failed to remove $rel"
+            record_error "failed to remove $rel — close any process holding files inside it, check directory permissions, then delete '$rel' manually before running \`tessl uninstall\`"
         fi
     fi
 }
@@ -121,7 +121,7 @@ strip_chain_call() {
 
     local tmp
     if ! tmp="$(mktemp 2>/dev/null)"; then
-        record_error "failed to allocate temp file while rewriting $rel"
+        record_error "could not create temp file while rewriting $rel — check that \$TMPDIR (or /tmp) is writable and has free space, then re-run \`/iikit-core uninit\`"
         return 1
     fi
 
@@ -132,18 +132,18 @@ strip_chain_call() {
         { print }
     ' "$hook" > "$tmp" 2>/dev/null; then
         rm -f "$tmp"
-        record_error "failed to filter $rel"
+        record_error "awk failed while filtering $rel — strip the '# IIKit assertion integrity check' block and the following iikit-$hook_name call line by hand, then re-run \`/iikit-core uninit\`"
         return 1
     fi
 
     if ! mv "$tmp" "$hook" 2>/dev/null; then
         rm -f "$tmp"
-        record_error "failed to overwrite $rel"
+        record_error "could not overwrite $rel — check write permission on the .git/hooks directory, then re-run \`/iikit-core uninit\`"
         return 1
     fi
 
     if ! chmod +x "$hook" 2>/dev/null; then
-        record_error "failed to restore exec bit on $rel"
+        record_error "could not restore exec bit on $rel — run \`chmod +x $rel\` manually so the hook still fires on commit"
         return 1
     fi
 

--- a/.claude/skills/iikit-core/scripts/bash/uninit.sh
+++ b/.claude/skills/iikit-core/scripts/bash/uninit.sh
@@ -112,6 +112,11 @@ strip_chain_call() {
     local hook_name="$2"
     local rel="${hook#"$REPO_ROOT/"}"
     [[ -f "$hook" ]] || return 0
+    # Require BOTH the marker comment line and the chain-call invocation.
+    # Gating on the call line alone would flag a user hook that merely
+    # mentions `iikit-pre-commit` in a comment, leading to a misleading
+    # `(stripped iikit chain-call)` report on a file the script did not change.
+    grep -qF '# IIKit assertion integrity check' "$hook" 2>/dev/null || return 0
     grep -q "iikit-$hook_name" "$hook" 2>/dev/null || return 0
 
     if $DRY_RUN; then

--- a/.claude/skills/iikit-core/scripts/powershell/uninit.ps1
+++ b/.claude/skills/iikit-core/scripts/powershell/uninit.ps1
@@ -51,18 +51,18 @@ function Remove-Path([string]$path) {
     try {
         Remove-Item $path -Recurse -Force -ErrorAction Stop
         if (Test-Path $path) {
-            $msg = "failed to remove $rel"
+            $msg = "failed to remove $rel — check that no process is holding files inside it, then delete '$rel' manually before running ``tessl uninstall``"
             $errors.Add($msg) | Out-Null
             [Console]::Error.WriteLine("[uninit] ERROR: $msg")
             return
         }
         $removed.Add($rel) | Out-Null
     } catch [System.UnauthorizedAccessException] {
-        $msg = "permission denied removing ${rel}: $($_.Exception.Message)"
+        $msg = "permission denied removing ${rel} ($($_.Exception.Message)) — re-run elevated (Run as Administrator) or grant write access on the parent directory, then re-run ``/iikit-core uninit``"
         $errors.Add($msg) | Out-Null
         [Console]::Error.WriteLine("[uninit] ERROR: $msg")
     } catch [System.IO.IOException] {
-        $msg = "I/O error removing ${rel}: $($_.Exception.Message)"
+        $msg = "I/O error removing ${rel} ($($_.Exception.Message)) — close any process or editor that has '$rel' open, then re-run ``/iikit-core uninit``"
         $errors.Add($msg) | Out-Null
         [Console]::Error.WriteLine("[uninit] ERROR: $msg")
     }
@@ -98,11 +98,11 @@ function Strip-ChainCall([string]$hookName) {
         Set-Content -Path $hook -Value $out -ErrorAction Stop
         $removed.Add("$rel (stripped iikit chain-call)") | Out-Null
     } catch [System.UnauthorizedAccessException] {
-        $msg = "permission denied rewriting ${rel}: $($_.Exception.Message)"
+        $msg = "permission denied rewriting ${rel} ($($_.Exception.Message)) — re-run elevated or grant write access on the .git/hooks directory, then re-run ``/iikit-core uninit``"
         $errors.Add($msg) | Out-Null
         [Console]::Error.WriteLine("[uninit] ERROR: $msg")
     } catch [System.IO.IOException] {
-        $msg = "I/O error rewriting ${rel}: $($_.Exception.Message)"
+        $msg = "I/O error rewriting ${rel} ($($_.Exception.Message)) — close any editor with '$rel' open and check disk space, then re-run ``/iikit-core uninit``"
         $errors.Add($msg) | Out-Null
         [Console]::Error.WriteLine("[uninit] ERROR: $msg")
     }

--- a/.claude/skills/iikit-core/scripts/powershell/uninit.ps1
+++ b/.claude/skills/iikit-core/scripts/powershell/uninit.ps1
@@ -76,22 +76,28 @@ function Strip-ChainCall([string]$hookName) {
         return
     }
 
-    $lines = Get-Content $hook
-    $out = New-Object System.Collections.Generic.List[string]
-    $skip = 0
-    foreach ($line in $lines) {
-        if ($skip -eq 0 -and $line -eq "# IIKit assertion integrity check") {
-            $skip = 2
-            continue
+    try {
+        $lines = Get-Content $hook -ErrorAction Stop
+        $out = New-Object System.Collections.Generic.List[string]
+        $skip = 0
+        foreach ($line in $lines) {
+            if ($skip -eq 0 -and $line -eq "# IIKit assertion integrity check") {
+                $skip = 2
+                continue
+            }
+            if ($skip -gt 0 -and ($line -match "iikit-$hookName" -or $line -eq "")) {
+                $skip--
+                continue
+            }
+            $out.Add($line) | Out-Null
         }
-        if ($skip -gt 0 -and ($line -match "iikit-$hookName" -or $line -eq "")) {
-            $skip--
-            continue
-        }
-        $out.Add($line) | Out-Null
+        Set-Content -Path $hook -Value $out -ErrorAction Stop
+        $removed.Add("$rel (stripped iikit chain-call)") | Out-Null
+    } catch {
+        $msg = "failed to rewrite ${rel}: $($_.Exception.Message)"
+        $errors.Add($msg) | Out-Null
+        [Console]::Error.WriteLine("[uninit] ERROR: $msg")
     }
-    Set-Content -Path $hook -Value $out
-    $removed.Add("$rel (stripped iikit chain-call)") | Out-Null
 }
 
 function Handle-Hook([string]$hookName, [string]$marker) {

--- a/.claude/skills/iikit-core/scripts/powershell/uninit.ps1
+++ b/.claude/skills/iikit-core/scripts/powershell/uninit.ps1
@@ -31,15 +31,32 @@ $hooksDir = Join-Path $repoRoot ".git/hooks"
 
 $removed = New-Object System.Collections.Generic.List[string]
 $userContent = New-Object System.Collections.Generic.List[string]
+$errors = New-Object System.Collections.Generic.List[string]
 
 function To-Relative([string]$abs) {
     return $abs.Substring($repoRoot.Length).TrimStart([char]'/', [char]'\')
 }
 
 function Remove-Path([string]$path) {
-    if (Test-Path $path) {
-        if (-not $DryRun) { Remove-Item $path -Recurse -Force -ErrorAction SilentlyContinue }
-        $removed.Add((To-Relative $path)) | Out-Null
+    if (-not (Test-Path $path)) { return }
+    $rel = To-Relative $path
+    if ($DryRun) {
+        $removed.Add($rel) | Out-Null
+        return
+    }
+    try {
+        Remove-Item $path -Recurse -Force -ErrorAction Stop
+        if (Test-Path $path) {
+            $msg = "failed to remove $rel"
+            $errors.Add($msg) | Out-Null
+            [Console]::Error.WriteLine("[uninit] ERROR: $msg")
+            return
+        }
+        $removed.Add($rel) | Out-Null
+    } catch {
+        $msg = "failed to remove ${rel}: $($_.Exception.Message)"
+        $errors.Add($msg) | Out-Null
+        [Console]::Error.WriteLine("[uninit] ERROR: $msg")
     }
 }
 
@@ -116,6 +133,7 @@ if ($Json) {
         dry_run      = [bool]$DryRun
         removed      = @($removed)
         user_content = @($userContent)
+        errors       = @($errors)
         next_step    = $nextStep
     }
     $result | ConvertTo-Json -Compress -Depth 3
@@ -135,3 +153,5 @@ if ($Json) {
     Write-Host ""
     Write-Host "[uninit] Next: $nextStep"
 }
+
+if ($errors.Count -gt 0) { exit 1 }

--- a/.claude/skills/iikit-core/scripts/powershell/uninit.ps1
+++ b/.claude/skills/iikit-core/scripts/powershell/uninit.ps1
@@ -1,0 +1,137 @@
+#!/usr/bin/env pwsh
+# Remove intent-integrity-kit scaffolding from a project so `tessl uninstall`
+# does not leave broken hooks, orphaned `.specify/`, or stale tile artifacts behind.
+# Run BEFORE `tessl uninstall tessl-labs/intent-integrity-kit`.
+[CmdletBinding()]
+param(
+    [Alias('j')]
+    [switch]$Json,
+    [switch]$DryRun,
+    [switch]$RemoveUserContent,
+    [Alias('h')]
+    [switch]$Help
+)
+
+$ErrorActionPreference = 'Stop'
+
+if ($Help) {
+    Write-Host "Usage: ./uninit.ps1 [-Json] [-DryRun] [-RemoveUserContent]"
+    Write-Host ""
+    Write-Host "Remove iikit scaffolding before tessl uninstall."
+    Write-Host ""
+    Write-Host "Options:"
+    Write-Host "  -Json                 Output JSON"
+    Write-Host "  -DryRun               Report what would change without modifying anything"
+    Write-Host "  -RemoveUserContent    Also delete CONSTITUTION.md, PREMISE.md, specs/"
+    exit 0
+}
+
+$repoRoot = (Get-Location).Path
+$hooksDir = Join-Path $repoRoot ".git/hooks"
+
+$removed = New-Object System.Collections.Generic.List[string]
+$userContent = New-Object System.Collections.Generic.List[string]
+
+function To-Relative([string]$abs) {
+    return $abs.Substring($repoRoot.Length).TrimStart([char]'/', [char]'\')
+}
+
+function Remove-Path([string]$path) {
+    if (Test-Path $path) {
+        if (-not $DryRun) { Remove-Item $path -Recurse -Force -ErrorAction SilentlyContinue }
+        $removed.Add((To-Relative $path)) | Out-Null
+    }
+}
+
+function Strip-ChainCall([string]$hookName) {
+    $hook = Join-Path $hooksDir $hookName
+    if (-not (Test-Path $hook)) { return }
+    $content = Get-Content $hook -Raw -ErrorAction SilentlyContinue
+    if ($content -notmatch "iikit-$hookName") { return }
+
+    $rel = To-Relative $hook
+    if ($DryRun) {
+        $removed.Add("$rel (stripped iikit chain-call)") | Out-Null
+        return
+    }
+
+    $lines = Get-Content $hook
+    $out = New-Object System.Collections.Generic.List[string]
+    $skip = 0
+    foreach ($line in $lines) {
+        if ($skip -eq 0 -and $line -eq "# IIKit assertion integrity check") {
+            $skip = 2
+            continue
+        }
+        if ($skip -gt 0 -and ($line -match "iikit-$hookName" -or $line -eq "")) {
+            $skip--
+            continue
+        }
+        $out.Add($line) | Out-Null
+    }
+    Set-Content -Path $hook -Value $out
+    $removed.Add("$rel (stripped iikit chain-call)") | Out-Null
+}
+
+function Handle-Hook([string]$hookName, [string]$marker) {
+    $hook = Join-Path $hooksDir $hookName
+    if ((Test-Path $hook) -and ((Get-Content $hook -Raw -ErrorAction SilentlyContinue) -match $marker)) {
+        Remove-Path $hook
+    } else {
+        Strip-ChainCall $hookName
+    }
+    Remove-Path (Join-Path $hooksDir "iikit-$hookName")
+}
+
+if (Test-Path $hooksDir) {
+    Handle-Hook "pre-commit"  "IIKIT-PRE-COMMIT"
+    Handle-Hook "post-commit" "IIKIT-POST-COMMIT"
+}
+
+Remove-Path (Join-Path $repoRoot ".specify")
+
+$techMd = Join-Path $repoRoot "TECH.md"
+if ((Test-Path $techMd) -and ((Get-Content $techMd -Raw -ErrorAction SilentlyContinue) -match '/iikit-\d{2}-')) {
+    Remove-Path $techMd
+}
+
+function Check-UserContent([string]$path) {
+    if (Test-Path $path) {
+        if ($RemoveUserContent) {
+            Remove-Path $path
+        } else {
+            $userContent.Add((To-Relative $path)) | Out-Null
+        }
+    }
+}
+
+Check-UserContent (Join-Path $repoRoot "CONSTITUTION.md")
+Check-UserContent (Join-Path $repoRoot "PREMISE.md")
+Check-UserContent (Join-Path $repoRoot "specs")
+
+$nextStep = "tessl uninstall tessl-labs/intent-integrity-kit"
+
+if ($Json) {
+    $result = [ordered]@{
+        dry_run      = [bool]$DryRun
+        removed      = @($removed)
+        user_content = @($userContent)
+        next_step    = $nextStep
+    }
+    $result | ConvertTo-Json -Compress -Depth 3
+} else {
+    if ($DryRun) { Write-Host "[uninit] DRY RUN — no files changed" }
+    if ($removed.Count -gt 0) {
+        Write-Host "[uninit] Removed:"
+        foreach ($p in $removed) { Write-Host "  - $p" }
+    } else {
+        Write-Host "[uninit] No tile-managed scaffolding found."
+    }
+    if ($userContent.Count -gt 0) {
+        Write-Host ""
+        Write-Host "[uninit] User-authored content kept (re-run with -RemoveUserContent to delete):"
+        foreach ($p in $userContent) { Write-Host "  - $p" }
+    }
+    Write-Host ""
+    Write-Host "[uninit] Next: $nextStep"
+}

--- a/.claude/skills/iikit-core/scripts/powershell/uninit.ps1
+++ b/.claude/skills/iikit-core/scripts/powershell/uninit.ps1
@@ -57,8 +57,12 @@ function Remove-Path([string]$path) {
             return
         }
         $removed.Add($rel) | Out-Null
-    } catch {
-        $msg = "failed to remove ${rel}: $($_.Exception.Message)"
+    } catch [System.UnauthorizedAccessException] {
+        $msg = "permission denied removing ${rel}: $($_.Exception.Message)"
+        $errors.Add($msg) | Out-Null
+        [Console]::Error.WriteLine("[uninit] ERROR: $msg")
+    } catch [System.IO.IOException] {
+        $msg = "I/O error removing ${rel}: $($_.Exception.Message)"
         $errors.Add($msg) | Out-Null
         [Console]::Error.WriteLine("[uninit] ERROR: $msg")
     }
@@ -93,8 +97,12 @@ function Strip-ChainCall([string]$hookName) {
         }
         Set-Content -Path $hook -Value $out -ErrorAction Stop
         $removed.Add("$rel (stripped iikit chain-call)") | Out-Null
-    } catch {
-        $msg = "failed to rewrite ${rel}: $($_.Exception.Message)"
+    } catch [System.UnauthorizedAccessException] {
+        $msg = "permission denied rewriting ${rel}: $($_.Exception.Message)"
+        $errors.Add($msg) | Out-Null
+        [Console]::Error.WriteLine("[uninit] ERROR: $msg")
+    } catch [System.IO.IOException] {
+        $msg = "I/O error rewriting ${rel}: $($_.Exception.Message)"
         $errors.Add($msg) | Out-Null
         [Console]::Error.WriteLine("[uninit] ERROR: $msg")
     }

--- a/.claude/skills/iikit-core/scripts/powershell/uninit.ps1
+++ b/.claude/skills/iikit-core/scripts/powershell/uninit.ps1
@@ -64,7 +64,7 @@ function Strip-ChainCall([string]$hookName) {
     $hook = Join-Path $hooksDir $hookName
     if (-not (Test-Path $hook)) { return }
     $content = Get-Content $hook -Raw -ErrorAction SilentlyContinue
-    if ($content -notmatch "iikit-$hookName") { return }
+    if ($content -cnotmatch "iikit-$hookName") { return }
 
     $rel = To-Relative $hook
     if ($DryRun) {
@@ -92,7 +92,12 @@ function Strip-ChainCall([string]$hookName) {
 
 function Handle-Hook([string]$hookName, [string]$marker) {
     $hook = Join-Path $hooksDir $hookName
-    if ((Test-Path $hook) -and ((Get-Content $hook -Raw -ErrorAction SilentlyContinue) -match $marker)) {
+    # Case-sensitive match — the marker is an uppercase tag (`IIKIT-PRE-COMMIT`)
+    # the iikit hook installer writes into its own files. The chain-call line a
+    # non-iikit hook contains uses the lowercase script name (`iikit-pre-commit`)
+    # and must not be treated as marker presence, otherwise the user's hook gets
+    # deleted instead of having the chain-call stripped.
+    if ((Test-Path $hook) -and ((Get-Content $hook -Raw -ErrorAction SilentlyContinue) -cmatch $marker)) {
         Remove-Path $hook
     } else {
         Strip-ChainCall $hookName

--- a/.claude/skills/iikit-core/scripts/powershell/uninit.ps1
+++ b/.claude/skills/iikit-core/scripts/powershell/uninit.ps1
@@ -72,6 +72,10 @@ function Strip-ChainCall([string]$hookName) {
     $hook = Join-Path $hooksDir $hookName
     if (-not (Test-Path $hook)) { return }
     $content = Get-Content $hook -Raw -ErrorAction SilentlyContinue
+    # Require BOTH the marker comment and the chain-call line — a hook that
+    # merely mentions `iikit-pre-commit` in a comment must not be treated
+    # as iikit-managed and rewritten.
+    if ($content -cnotmatch '# IIKit assertion integrity check') { return }
     if ($content -cnotmatch "iikit-$hookName") { return }
 
     $rel = To-Relative $hook

--- a/.claude/skills/iikit-core/scripts/powershell/uninit.ps1
+++ b/.claude/skills/iikit-core/scripts/powershell/uninit.ps1
@@ -26,7 +26,11 @@ if ($Help) {
     exit 0
 }
 
-$repoRoot = (Get-Location).Path
+# Resolve the actual git repo root so a sub-directory invocation still
+# operates on the top of the project (matches bash's get_repo_root behavior).
+$repoRoot = git rev-parse --show-toplevel 2>$null
+if (-not $repoRoot) { $repoRoot = (Get-Location).Path }
+$repoRoot = (Resolve-Path $repoRoot).Path
 $hooksDir = Join-Path $repoRoot ".git/hooks"
 
 $removed = New-Object System.Collections.Generic.List[string]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ Intent Integrity Kit (IIKit) preserves your intent from idea to implementation t
 
 This project uses specification-driven development. The phases are:
 
-**Utility:** `/iikit-core` - Initialize project (git/GitHub setup, PRD seeding), check status, select active feature, show help (run `init` before starting)
+**Utility:** `/iikit-core` - Initialize project (git/GitHub setup, PRD seeding), uninit before `tessl uninstall`, check status, select active feature, show help (run `init` before starting)
 **Utility:** `/iikit-clarify` - Resolve ambiguities in any artifact (spec, plan, checklist, testify, tasks, constitution) — runnable after any phase
 **Utility:** `/iikit-bugfix` - Report and fix bugs without full specification workflow
 
@@ -92,7 +92,7 @@ chmod +x .claude/skills/iikit-core/scripts/bash/*.sh
 
 | Skill | Command | Description |
 |-------|---------|-------------|
-| Core | `/iikit-core` | Initialize project (git/GitHub setup, PRD seeding), check status, select feature, show help |
+| Core | `/iikit-core` | Initialize project, uninit before `tessl uninstall`, check status, select feature, show help |
 | Clarify | `/iikit-clarify` | Resolve ambiguities in any artifact (utility, runnable after any phase) |
 | Bugfix | `/iikit-bugfix` | Report and fix bugs without full specification workflow |
 | Constitution | `/iikit-00-constitution` | Create project governance principles |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Features
+- **`/iikit-core uninit` subcommand** (#62): New action that removes iikit-managed scaffolding (`.git/hooks/pre-commit`/`post-commit` IIKit blocks, alongside `iikit-*` hooks, chain-call lines in user hooks, `.specify/`, `TECH.md` when it carries an iikit phase reference) and reports user-authored content (`CONSTITUTION.md`, `PREMISE.md`, `specs/`) so the user decides. Run it BEFORE `tessl uninstall tessl-labs/intent-integrity-kit` to avoid orphaned hooks and stale tile artifacts. Supports `--dry-run` and `--remove-user-content`. BATS + Pester coverage.
+
 ### Bug Fixes
 - **Symlinked `tests/features/` not traversed by `find`** (#59): Every `find` over `.feature` files in `iikit-core` scripts (`check-prerequisites.sh`, `pre-commit-hook.sh`, `bugfix-helpers.sh`, `verify-assertion-integrity.sh`, `verify-steps.sh`) now passes `-L` so a symlinked `tests/features/` directory (e.g., Maven layout where it points to `src/test/resources/features/`) is followed. Previously the testify gate falsely reported `"features": false` and blocked phases 05–08 even when `.feature` files existed.
 

--- a/tests/bash/uninit.bats
+++ b/tests/bash/uninit.bats
@@ -171,6 +171,10 @@ EOF
 }
 
 @test "uninit: --json with no scaffolding still emits a valid envelope" {
+    # setup_test_dir creates .specify/ and specs/ — clear them so the script
+    # has nothing to clean up or report.
+    rm -rf "$TEST_DIR/.specify" "$TEST_DIR/specs"
+
     result=$("$UNINIT_SCRIPT" --json)
 
     assert_contains "$result" '"removed":[]'

--- a/tests/bash/uninit.bats
+++ b/tests/bash/uninit.bats
@@ -171,9 +171,10 @@ EOF
 }
 
 @test "uninit: --json with no scaffolding still emits a valid envelope" {
-    # setup_test_dir creates .specify/ and specs/ — clear them so the script
-    # has nothing to clean up or report.
+    # setup_test_dir creates .specify/, specs/, and CONSTITUTION.md — clear them
+    # so the script has nothing to clean up or report.
     rm -rf "$TEST_DIR/.specify" "$TEST_DIR/specs"
+    rm -f "$TEST_DIR/CONSTITUTION.md"
 
     result=$("$UNINIT_SCRIPT" --json)
 

--- a/tests/bash/uninit.bats
+++ b/tests/bash/uninit.bats
@@ -1,0 +1,178 @@
+#!/usr/bin/env bats
+# Tests for uninit.sh — removes iikit scaffolding before `tessl uninstall`.
+
+load 'test_helper'
+
+UNINIT_SCRIPT="$REPO_ROOT/tiles/intent-integrity-kit/skills/iikit-core/scripts/bash/uninit.sh"
+HOOKS_SUBDIR=".git/hooks"
+
+setup() {
+    setup_test_dir
+    cd "$TEST_DIR" || return 1
+}
+
+teardown() {
+    cd /
+    teardown_test_dir
+}
+
+# Helper: install a marker-owned iikit hook in the test repo.
+install_marker_hook() {
+    local hook="$1"
+    local marker="$2"
+    cat > "$TEST_DIR/$HOOKS_SUBDIR/$hook" <<EOF
+#!/usr/bin/env bash
+# $marker
+echo iikit-$hook
+EOF
+    chmod +x "$TEST_DIR/$HOOKS_SUBDIR/$hook"
+}
+
+# =============================================================================
+# Tile-managed scaffolding removal
+# =============================================================================
+
+@test "uninit: removes marker-owned pre-commit hook" {
+    install_marker_hook "pre-commit" "IIKIT-PRE-COMMIT"
+
+    "$UNINIT_SCRIPT" --json
+
+    [[ ! -f "$TEST_DIR/$HOOKS_SUBDIR/pre-commit" ]]
+}
+
+@test "uninit: removes marker-owned post-commit hook" {
+    install_marker_hook "post-commit" "IIKIT-POST-COMMIT"
+
+    "$UNINIT_SCRIPT" --json
+
+    [[ ! -f "$TEST_DIR/$HOOKS_SUBDIR/post-commit" ]]
+}
+
+@test "uninit: keeps non-iikit hook untouched" {
+    cat > "$TEST_DIR/$HOOKS_SUBDIR/pre-commit" <<'EOF'
+#!/usr/bin/env bash
+echo user hook
+EOF
+    chmod +x "$TEST_DIR/$HOOKS_SUBDIR/pre-commit"
+
+    "$UNINIT_SCRIPT" --json
+
+    [[ -f "$TEST_DIR/$HOOKS_SUBDIR/pre-commit" ]]
+    grep -q "user hook" "$TEST_DIR/$HOOKS_SUBDIR/pre-commit"
+}
+
+@test "uninit: strips iikit chain-call from existing user hook" {
+    cat > "$TEST_DIR/$HOOKS_SUBDIR/post-commit" <<'EOF'
+#!/usr/bin/env bash
+echo user post-commit
+
+# IIKit assertion integrity check
+"$(dirname "$0")/iikit-post-commit"
+EOF
+    chmod +x "$TEST_DIR/$HOOKS_SUBDIR/post-commit"
+    install_marker_hook "iikit-post-commit" "IIKIT-POST-COMMIT"
+
+    "$UNINIT_SCRIPT" --json
+
+    [[ -f "$TEST_DIR/$HOOKS_SUBDIR/post-commit" ]]
+    ! grep -q "iikit-post-commit" "$TEST_DIR/$HOOKS_SUBDIR/post-commit"
+    ! grep -q "IIKit assertion integrity check" "$TEST_DIR/$HOOKS_SUBDIR/post-commit"
+    grep -q "echo user post-commit" "$TEST_DIR/$HOOKS_SUBDIR/post-commit"
+}
+
+@test "uninit: removes alongside iikit-<hook> file" {
+    install_marker_hook "iikit-pre-commit" "IIKIT-PRE-COMMIT"
+
+    "$UNINIT_SCRIPT" --json
+
+    [[ ! -f "$TEST_DIR/$HOOKS_SUBDIR/iikit-pre-commit" ]]
+}
+
+@test "uninit: removes .specify directory" {
+    mkdir -p "$TEST_DIR/.specify"
+    touch "$TEST_DIR/.specify/context.json"
+
+    "$UNINIT_SCRIPT" --json
+
+    [[ ! -d "$TEST_DIR/.specify" ]]
+}
+
+@test "uninit: removes TECH.md only when it references an iikit phase" {
+    echo "Pre-plan notes referencing /iikit-02-plan" > "$TEST_DIR/TECH.md"
+
+    "$UNINIT_SCRIPT" --json
+
+    [[ ! -f "$TEST_DIR/TECH.md" ]]
+}
+
+@test "uninit: preserves TECH.md when it does not reference an iikit phase" {
+    echo "Generic technical notes — no iikit content here" > "$TEST_DIR/TECH.md"
+
+    "$UNINIT_SCRIPT" --json
+
+    [[ -f "$TEST_DIR/TECH.md" ]]
+}
+
+# =============================================================================
+# User-authored content reporting
+# =============================================================================
+
+@test "uninit: lists user content but does not delete by default" {
+    echo "# Constitution" > "$TEST_DIR/CONSTITUTION.md"
+    echo "# Premise" > "$TEST_DIR/PREMISE.md"
+    mkdir -p "$TEST_DIR/specs/001-foo"
+
+    result=$("$UNINIT_SCRIPT" --json)
+
+    [[ -f "$TEST_DIR/CONSTITUTION.md" ]]
+    [[ -f "$TEST_DIR/PREMISE.md" ]]
+    [[ -d "$TEST_DIR/specs/001-foo" ]]
+    assert_contains "$result" "CONSTITUTION.md"
+    assert_contains "$result" "PREMISE.md"
+    assert_contains "$result" "specs"
+}
+
+@test "uninit: --remove-user-content deletes user-authored files" {
+    echo "# Constitution" > "$TEST_DIR/CONSTITUTION.md"
+    echo "# Premise" > "$TEST_DIR/PREMISE.md"
+    mkdir -p "$TEST_DIR/specs/001-foo"
+
+    "$UNINIT_SCRIPT" --json --remove-user-content
+
+    [[ ! -f "$TEST_DIR/CONSTITUTION.md" ]]
+    [[ ! -f "$TEST_DIR/PREMISE.md" ]]
+    [[ ! -d "$TEST_DIR/specs" ]]
+}
+
+# =============================================================================
+# --dry-run
+# =============================================================================
+
+@test "uninit: --dry-run reports without modifying anything" {
+    install_marker_hook "pre-commit" "IIKIT-PRE-COMMIT"
+    mkdir -p "$TEST_DIR/.specify"
+
+    result=$("$UNINIT_SCRIPT" --json --dry-run)
+
+    [[ -f "$TEST_DIR/$HOOKS_SUBDIR/pre-commit" ]]
+    [[ -d "$TEST_DIR/.specify" ]]
+    assert_contains "$result" '"dry_run":true'
+    assert_contains "$result" ".specify"
+}
+
+# =============================================================================
+# JSON shape
+# =============================================================================
+
+@test "uninit: JSON output includes next_step pointing at tessl uninstall" {
+    result=$("$UNINIT_SCRIPT" --json)
+
+    assert_contains "$result" "tessl uninstall tessl-labs/intent-integrity-kit"
+}
+
+@test "uninit: --json with no scaffolding still emits a valid envelope" {
+    result=$("$UNINIT_SCRIPT" --json)
+
+    assert_contains "$result" '"removed":[]'
+    assert_contains "$result" '"user_content":[]'
+}

--- a/tests/powershell/uninit.Tests.ps1
+++ b/tests/powershell/uninit.Tests.ps1
@@ -4,16 +4,16 @@ BeforeAll {
     Import-Module $PSScriptRoot/TestHelper.psm1 -Force
     $script:UninitScript = Join-Path (Split-Path -Parent (Split-Path -Parent $PSScriptRoot)) "tiles/intent-integrity-kit/skills/iikit-core/scripts/powershell/uninit.ps1"
     $script:HooksSubdir = ".git/hooks"
-}
 
-function Install-MarkerHook {
-    param([string]$TestDir, [string]$Hook, [string]$Marker)
-    $hookPath = Join-Path $TestDir "$script:HooksSubdir/$Hook"
-    @(
-        "#!/usr/bin/env bash",
-        "# $Marker",
-        "echo iikit-$Hook"
-    ) | Set-Content $hookPath
+    function Install-MarkerHook {
+        param([string]$TestDir, [string]$Hook, [string]$Marker)
+        $hookPath = Join-Path $TestDir ".git/hooks/$Hook"
+        @(
+            "#!/usr/bin/env bash",
+            "# $Marker",
+            "echo iikit-$Hook"
+        ) | Set-Content $hookPath
+    }
 }
 
 Describe "uninit: tile-managed scaffolding" {

--- a/tests/powershell/uninit.Tests.ps1
+++ b/tests/powershell/uninit.Tests.ps1
@@ -1,0 +1,187 @@
+# Tests for uninit.ps1 — removes iikit scaffolding before `tessl uninstall`.
+
+BeforeAll {
+    Import-Module $PSScriptRoot/TestHelper.psm1 -Force
+    $script:UninitScript = Join-Path (Split-Path -Parent (Split-Path -Parent $PSScriptRoot)) "tiles/intent-integrity-kit/skills/iikit-core/scripts/powershell/uninit.ps1"
+    $script:HooksSubdir = ".git/hooks"
+}
+
+function Install-MarkerHook {
+    param([string]$TestDir, [string]$Hook, [string]$Marker)
+    $hookPath = Join-Path $TestDir "$script:HooksSubdir/$Hook"
+    @(
+        "#!/usr/bin/env bash",
+        "# $Marker",
+        "echo iikit-$Hook"
+    ) | Set-Content $hookPath
+}
+
+Describe "uninit: tile-managed scaffolding" {
+    BeforeEach {
+        $script:TestDir = New-TestDirectory
+        Push-Location $script:TestDir
+        # The TestHelper installs CONSTITUTION.md and a memory copy; strip them so
+        # individual tests start without preconditions they did not opt into.
+        Remove-Item "CONSTITUTION.md" -Force -ErrorAction SilentlyContinue
+    }
+
+    AfterEach {
+        Pop-Location
+        Remove-TestDirectory -TestDir $script:TestDir
+    }
+
+    It "removes marker-owned pre-commit hook" {
+        Install-MarkerHook -TestDir $script:TestDir -Hook "pre-commit" -Marker "IIKIT-PRE-COMMIT"
+
+        & $script:UninitScript -Json | Out-Null
+
+        (Test-Path (Join-Path $script:TestDir "$script:HooksSubdir/pre-commit")) | Should -BeFalse
+    }
+
+    It "removes marker-owned post-commit hook" {
+        Install-MarkerHook -TestDir $script:TestDir -Hook "post-commit" -Marker "IIKIT-POST-COMMIT"
+
+        & $script:UninitScript -Json | Out-Null
+
+        (Test-Path (Join-Path $script:TestDir "$script:HooksSubdir/post-commit")) | Should -BeFalse
+    }
+
+    It "keeps non-iikit hook untouched" {
+        @(
+            "#!/usr/bin/env bash",
+            "echo user hook"
+        ) | Set-Content (Join-Path $script:TestDir "$script:HooksSubdir/pre-commit")
+
+        & $script:UninitScript -Json | Out-Null
+
+        $hook = Get-Content (Join-Path $script:TestDir "$script:HooksSubdir/pre-commit") -Raw
+        $hook | Should -Match "echo user hook"
+    }
+
+    It "strips iikit chain-call from existing user hook" {
+        @(
+            "#!/usr/bin/env bash",
+            "echo user post-commit",
+            "",
+            "# IIKit assertion integrity check",
+            '"$(dirname "$0")/iikit-post-commit"'
+        ) | Set-Content (Join-Path $script:TestDir "$script:HooksSubdir/post-commit")
+        Install-MarkerHook -TestDir $script:TestDir -Hook "iikit-post-commit" -Marker "IIKIT-POST-COMMIT"
+
+        & $script:UninitScript -Json | Out-Null
+
+        $hook = Get-Content (Join-Path $script:TestDir "$script:HooksSubdir/post-commit") -Raw
+        $hook | Should -Match "echo user post-commit"
+        $hook | Should -Not -Match "iikit-post-commit"
+        $hook | Should -Not -Match "IIKit assertion integrity check"
+    }
+
+    It "removes .specify directory" {
+        New-Item -ItemType Directory -Path (Join-Path $script:TestDir ".specify") -Force | Out-Null
+        "{}" | Set-Content (Join-Path $script:TestDir ".specify/context.json")
+
+        & $script:UninitScript -Json | Out-Null
+
+        (Test-Path (Join-Path $script:TestDir ".specify")) | Should -BeFalse
+    }
+
+    It "removes TECH.md only when it references an iikit phase" {
+        "Pre-plan notes referencing /iikit-02-plan" | Set-Content (Join-Path $script:TestDir "TECH.md")
+
+        & $script:UninitScript -Json | Out-Null
+
+        (Test-Path (Join-Path $script:TestDir "TECH.md")) | Should -BeFalse
+    }
+
+    It "preserves TECH.md when it does not reference an iikit phase" {
+        "Generic technical notes" | Set-Content (Join-Path $script:TestDir "TECH.md")
+
+        & $script:UninitScript -Json | Out-Null
+
+        (Test-Path (Join-Path $script:TestDir "TECH.md")) | Should -BeTrue
+    }
+}
+
+Describe "uninit: user-authored content" {
+    BeforeEach {
+        $script:TestDir = New-TestDirectory
+        Push-Location $script:TestDir
+        Remove-Item "CONSTITUTION.md" -Force -ErrorAction SilentlyContinue
+    }
+
+    AfterEach {
+        Pop-Location
+        Remove-TestDirectory -TestDir $script:TestDir
+    }
+
+    It "lists user content but does not delete by default" {
+        "# Constitution" | Set-Content (Join-Path $script:TestDir "CONSTITUTION.md")
+        "# Premise" | Set-Content (Join-Path $script:TestDir "PREMISE.md")
+        New-Item -ItemType Directory -Path (Join-Path $script:TestDir "specs/001-foo") -Force | Out-Null
+
+        $result = & $script:UninitScript -Json
+
+        (Test-Path (Join-Path $script:TestDir "CONSTITUTION.md")) | Should -BeTrue
+        (Test-Path (Join-Path $script:TestDir "PREMISE.md")) | Should -BeTrue
+        (Test-Path (Join-Path $script:TestDir "specs/001-foo")) | Should -BeTrue
+        $result | Should -Match "CONSTITUTION.md"
+        $result | Should -Match "PREMISE.md"
+        $result | Should -Match "specs"
+    }
+
+    It "-RemoveUserContent deletes user-authored files" {
+        "# Constitution" | Set-Content (Join-Path $script:TestDir "CONSTITUTION.md")
+        "# Premise" | Set-Content (Join-Path $script:TestDir "PREMISE.md")
+        New-Item -ItemType Directory -Path (Join-Path $script:TestDir "specs/001-foo") -Force | Out-Null
+
+        & $script:UninitScript -Json -RemoveUserContent | Out-Null
+
+        (Test-Path (Join-Path $script:TestDir "CONSTITUTION.md")) | Should -BeFalse
+        (Test-Path (Join-Path $script:TestDir "PREMISE.md")) | Should -BeFalse
+        (Test-Path (Join-Path $script:TestDir "specs")) | Should -BeFalse
+    }
+}
+
+Describe "uninit: -DryRun" {
+    BeforeEach {
+        $script:TestDir = New-TestDirectory
+        Push-Location $script:TestDir
+        Remove-Item "CONSTITUTION.md" -Force -ErrorAction SilentlyContinue
+    }
+
+    AfterEach {
+        Pop-Location
+        Remove-TestDirectory -TestDir $script:TestDir
+    }
+
+    It "reports without modifying anything" {
+        Install-MarkerHook -TestDir $script:TestDir -Hook "pre-commit" -Marker "IIKIT-PRE-COMMIT"
+        New-Item -ItemType Directory -Path (Join-Path $script:TestDir ".specify") -Force | Out-Null
+
+        $result = & $script:UninitScript -Json -DryRun
+
+        (Test-Path (Join-Path $script:TestDir "$script:HooksSubdir/pre-commit")) | Should -BeTrue
+        (Test-Path (Join-Path $script:TestDir ".specify")) | Should -BeTrue
+        $result | Should -Match '"dry_run":\s*true'
+        $result | Should -Match "\.specify"
+    }
+}
+
+Describe "uninit: JSON shape" {
+    BeforeEach {
+        $script:TestDir = New-TestDirectory
+        Push-Location $script:TestDir
+        Remove-Item "CONSTITUTION.md" -Force -ErrorAction SilentlyContinue
+    }
+
+    AfterEach {
+        Pop-Location
+        Remove-TestDirectory -TestDir $script:TestDir
+    }
+
+    It "includes next_step pointing at tessl uninstall" {
+        $result = & $script:UninitScript -Json
+
+        $result | Should -Match "tessl uninstall tessl-labs/intent-integrity-kit"
+    }
+}

--- a/tiles/intent-integrity-kit/README.md
+++ b/tiles/intent-integrity-kit/README.md
@@ -106,7 +106,7 @@ Each phase builds on the previous. Never skip phases.
 
 ```
 ┌────────────────────────────────────────────────────────────────────────────┐
-│  /iikit-core               →  Initialize project, status, help             │
+│  /iikit-core               →  Initialize/uninit project, status, help      │
 │  /iikit-clarify            →  Resolve ambiguities (any artifact, any time) │
 │  /iikit-bugfix             →  Report and fix bugs                          │
 ├────────────────────────────────────────────────────────────────────────────┤


### PR DESCRIPTION
**Author-Model:** claude-opus-4-7

## Summary
- Adds a new `uninit` subcommand to `iikit-core` that strips iikit-managed scaffolding (`.git/hooks/{pre,post}-commit` IIKit blocks, alongside `iikit-*` hooks, chain-call lines in user hooks, `.specify/`, `TECH.md` when it carries an iikit phase reference) before the user runs `tessl uninstall tessl-labs/intent-integrity-kit`
- Reports user-authored artifacts (`CONSTITUTION.md`, `PREMISE.md`, `specs/`) so the caller decides whether to keep them — these often outlive the tile. `--dry-run` previews; `--remove-user-content` opts into deletion
- BATS + Pester parity coverage; README/AGENTS.md/CHANGELOG updated. Closes #62

## Test plan
- [ ] CI BATS suite passes (new `uninit.bats` covers marker hooks, chain-call strip, `.specify/`, TECH.md heuristic, user-content listing, `--dry-run`, JSON envelope shape)
- [ ] CI Pester suite passes (`uninit.Tests.ps1` mirrors the bats coverage on Windows)
- [ ] Unit & Source tests still green