### PR TITLE
fix(prepare-tile): keep hook-chaining.md in iikit-core/references on publish

### DIFF
--- a/tests/prepare-tile.sh
+++ b/tests/prepare-tile.sh
@@ -193,8 +193,8 @@ done
 echo "✓ Scripts distributed to skills"
 
 # Step 3: Clean up iikit-core — distributed files no longer needed in published tile
-# Keep references that iikit-core/SKILL.md itself uses (prd-seeding.md, help-reference.md)
-CORE_ONLY_REFS="prd-seeding.md help-reference.md"
+# Keep references that iikit-core/SKILL.md itself uses
+CORE_ONLY_REFS="prd-seeding.md help-reference.md hook-chaining.md"
 mkdir -p /tmp/iikit-core-refs-keep
 for ref in $CORE_ONLY_REFS; do
     [[ -f "iikit-core/references/$ref" ]] && cp "iikit-core/references/$ref" /tmp/iikit-core-refs-keep/


### PR DESCRIPTION
**Author-Model:** claude-opus-4-7

Follow-up to #66. Recovery for the failed 2.10.5 publish.

## Summary

\`prepare-tile.sh\` Step 3 deletes everything from \`iikit-core/references/\` except files in the hard-coded \`CORE_ONLY_REFS\` allowlist, then restores only those files. PR #66 added \`hook-chaining.md\` as a new iikit-core reference but did not add it to the allowlist, so the published tile ended up with SKILL.md linking a file the prepare step had just removed.

The publish run for #66 (CI run 26322200090) failed with:

\`\`\`
✘ Missing tile content: File not found: skills/iikit-core/references/hook-chaining.md (referenced from skills/iikit-core/SKILL.md)
\`\`\`

## Fix

Add \`hook-chaining.md\` to \`CORE_ONLY_REFS\` in \`tests/prepare-tile.sh\` so it's preserved during the clean-up step.

## Test plan

- [ ] Local \`tessl tile publish --dry-run --bump patch\` passes (validated before pushing).
- [ ] Once merged, the next auto-bumped publish lands a clean tile version that includes \`hook-chaining.md\`.