### PR TITLE
fix(ci): resolve symlinks before tile lint to unblock publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,27 @@ jobs:
           fi
           rm -rf "$TESTDIR"
 
+      - name: Resolve symlinks in tile directory (for lint)
+        run: |
+          cd tiles/intent-integrity-kit
+          git ls-files -s . | grep '^120000' | awk '{print $4}' | while read link; do
+            target=$(readlink -f "$link" 2>/dev/null)
+            if [ -z "$target" ] || [ ! -e "$target" ]; then
+              target=$(cat "$link")
+              target=$(cd "$(dirname "$link")" && readlink -f "$target")
+            fi
+            if [ -d "$target" ]; then
+              rm "$link"
+              cp -R "$target" "$link"
+            elif [ -f "$target" ]; then
+              rm "$link"
+              cp "$target" "$link"
+            fi
+          done
+
+      - name: Make skills self-contained (for lint)
+        run: bash tests/prepare-tile.sh tiles/intent-integrity-kit/skills
+
       - name: Lint tile manifest
         run: tessl tile lint tiles/intent-integrity-kit
 


### PR DESCRIPTION
**Author-Model:** claude-opus-4-7

Closes #83. Unblocks the publish workflow on main (currently red because of this).

## Summary

Mirror the publish job's two pre-package steps in the test job, immediately before \`tessl tile lint\`:
1. Resolve symlinks in \`tiles/intent-integrity-kit/\` (replaces the tracked \`skills/\` symlink with a real copy of its target)
2. Run \`tests/prepare-tile.sh\` to make each skill self-contained

The publish job already does these (ci.yml lines 187-213) before \`tesslio/patch-version-publish\`. The test job's lint was running on the raw symlink-laden tree, so Tessl 0.81+'s stricter lint flagged every \`skills/iikit-*\` path as excluded-by-gitignore (it doesn't follow unfollowed symlinks past mode-120000 blobs).

## Why

Verified locally:
\`\`\`
$ tessl tile lint tiles/intent-integrity-kit  # without fix
✘ Plugin manifest references paths that exist on disk but were excluded...

$ # apply the two new steps locally, then:
$ tessl tile lint tiles/intent-integrity-kit
✔ Plugin tessl-labs/intent-integrity-kit@2.10.6 is valid
\`\`\`

Currently main's CI is red on this same check, which gates \`publish\` (\`needs: [test, test-windows]\`). Result: PR #81 merged the path-rename fix, but no new tile got published — the registry is still serving the broken v2.10.6. This PR is the unblock.

## Test plan

- [x] Local repro: \`tessl tile lint\` passes after applying the two new steps
- [ ] CI: \`Lint tile manifest\` step on this PR is green
- [ ] After merge: main's CI goes green, \`tesslio/patch-version-publish\` runs, registry advances past 2.10.6